### PR TITLE
smitebot: add working doctor command (checks + --json + docs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +196,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +243,12 @@ checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "cpufeatures"
@@ -230,6 +326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +360,12 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -308,6 +416,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -531,6 +645,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "smitebot"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,9 +669,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -603,6 +734,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,9 +747,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen",
 ]
@@ -634,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "3"
 members = [
   "smite",
+  "smitebot",
   "smite-ir",
   "smite-ir-mutator",
   "smite-nyx-sys",

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ firefox ./$TARGET-$SCENARIO-coverage-report/html/index.html
 
 ```
 smite/              # Core Rust library (runners, scenarios, noise protocol, BOLT messages)
+smitebot/           # Automation CLI (doctor and upcoming campaign orchestration commands)
 smite-ir/           # IR types, generators, and mutators for structured fuzzing programs
 smite-ir-mutator/   # AFL++ custom mutator cdylib for IR programs
 smite-nyx-sys/      # Nyx FFI bindings

--- a/smitebot/Cargo.toml
+++ b/smitebot/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "smitebot"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+clap = { version = "4.6", features = ["derive"] }
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/smitebot/README.md
+++ b/smitebot/README.md
@@ -1,0 +1,56 @@
+# smitebot
+
+`smitebot` is the Smite automation CLI. It is intended to orchestrate common fuzzing workflows and reduce manual setup/operations.
+
+## Install
+
+Install `smitebot` once from this repository:
+
+```bash
+cargo install --path smitebot
+```
+
+After install, run it directly:
+
+```bash
+smitebot doctor --aflpp-path ~/AFLplusplus
+smitebot doctor --aflpp-path ~/AFLplusplus --json
+```
+
+## Commands
+
+### smitebot doctor
+
+`smitebot doctor` validates host prerequisites before running Smite campaigns.
+
+```bash
+smitebot doctor --aflpp-path ~/AFLplusplus --smite-dir .
+smitebot doctor --aflpp-path ~/AFLplusplus --smite-dir . --json
+```
+
+## Checks
+
+- `x86_64` architecture
+- CPU virtualization enabled (`vmx` or `svm`)
+- `/dev/kvm` is present and openable
+- Docker daemon is reachable (`docker version`)
+- AFL++ built with Nyx support (`libnyx.so` under `--aflpp-path`)
+- VMware backdoor is enabled
+- AFL++ tools (`afl-fuzz`, `afl-cmin`, `afl-tmin`, `afl-whatsup`) are executable under `--aflpp-path`
+- Required host tools (`bash`, `python`, `python3`)
+- Required Smite scripts are present and executable
+- Required workload Dockerfiles are present
+
+## JSON output
+
+By default, output is in a human readable format. The `--json` flag changes output to structured JSON:
+
+```json
+{
+  "checks": [
+    { "name": "x86_64 architecture", "passed": true },
+    { "name": "Docker daemon reachable", "passed": false, "reason": "docker version: exit status: 1" }
+  ],
+  "overall": false
+}
+```

--- a/smitebot/src/commands.rs
+++ b/smitebot/src/commands.rs
@@ -1,0 +1,3 @@
+pub mod doctor;
+
+pub use doctor::{DoctorArgs, DoctorCommand};

--- a/smitebot/src/commands/doctor.rs
+++ b/smitebot/src/commands/doctor.rs
@@ -1,0 +1,427 @@
+//! Host prerequisite checks for Smite fuzzing campaigns.
+//! The output is intentionally stable so CI and operators can diff or parse it.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use clap::Args;
+use serde::Serialize;
+
+use crate::utils::{find_in_path, is_executable};
+
+/// AFL++ binaries required for campaign execution and corpus minimization.
+const AFL_TOOLS: &[&str] = &["afl-fuzz", "afl-cmin", "afl-tmin", "afl-whatsup"];
+
+/// Host tools required by Smite helper scripts.
+const HOST_TOOLS: &[&str] = &["bash", "python", "python3"];
+
+/// Repository scripts required by doctor and upcoming orchestration commands.
+const REQUIRED_SCRIPTS: &[&str] = &[
+    "setup-nyx.sh",
+    "coverage-report.sh",
+    "symbolize-crash.sh",
+    "enable-vmware-backdoor.sh",
+];
+
+/// Workload Dockerfiles required for normal and coverage image builds.
+const REQUIRED_DOCKERFILES: &[&str] = &[
+    "workloads/lnd/Dockerfile",
+    "workloads/lnd/Dockerfile.coverage",
+    "workloads/ldk/Dockerfile",
+    "workloads/ldk/Dockerfile.coverage",
+    "workloads/cln/Dockerfile",
+    "workloads/cln/Dockerfile.coverage",
+    "workloads/eclair/Dockerfile",
+    "workloads/eclair/Dockerfile.coverage",
+];
+
+/// Command handler for `smitebot doctor`.
+pub struct DoctorCommand;
+
+/// CLI arguments for `smitebot doctor`.
+#[derive(Debug, Args)]
+pub struct DoctorArgs {
+    /// Emit machine-readable JSON output.
+    #[arg(long)]
+    json: bool,
+    /// Path to AFL++ source tree used for fuzzing.
+    #[arg(long)]
+    aflpp_path: PathBuf,
+    /// Path to smite repository root.
+    #[arg(long, default_value = ".")]
+    smite_dir: PathBuf,
+}
+
+/// A single prerequisite check and its outcome.
+#[derive(Debug, Serialize)]
+struct DoctorCheck {
+    name: String,
+    passed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<CheckFailure>,
+}
+
+impl DoctorCheck {
+    /// Creates a report entry from a named doctor check result.
+    fn new(name: impl Into<String>, result: Result<(), CheckFailure>) -> Self {
+        Self {
+            name: name.into(),
+            passed: result.is_ok(),
+            reason: result.err(),
+        }
+    }
+}
+
+/// Aggregate report for human output or JSON serialization.
+#[derive(Debug, Serialize)]
+struct DoctorReport {
+    overall: bool,
+    checks: Vec<DoctorCheck>,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum CheckFailure {
+    #[error("unsupported architecture: {0}")]
+    UnsupportedArchitecture(String),
+    #[error("neither vmx nor svm flag found in /proc/cpuinfo")]
+    MissingCpuVirtualization,
+    #[error("{} not found", .0.display())]
+    MissingPath(PathBuf),
+    #[error("{} not executable", .0.display())]
+    NotExecutable(PathBuf),
+    #[error("{}: {error}", path.display())]
+    Io {
+        path: PathBuf,
+        #[source]
+        error: io::Error,
+    },
+    #[error("{0} not found on PATH")]
+    ToolNotFound(String),
+    #[error("{command}: {detail}")]
+    Command { command: String, detail: String },
+    #[error("libnyx.so not found under --aflpp-path")]
+    LibnyxNotFound,
+    #[error("backdoor disabled; run ./scripts/enable-vmware-backdoor.sh to enable")]
+    VMwareBackdoorDisabled,
+}
+
+impl CheckFailure {
+    /// Creates an I/O failure associated with a filesystem path.
+    fn io(path: &Path, error: io::Error) -> Self {
+        Self::Io {
+            path: path.to_path_buf(),
+            error,
+        }
+    }
+}
+
+impl Serialize for CheckFailure {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // Keep JSON schema simple: serialize as the user-facing string.
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl DoctorCommand {
+    /// Runs all doctor checks and prints either human-readable or JSON output.
+    pub fn execute(args: &DoctorArgs) -> bool {
+        let aflpp_root = args.aflpp_path.as_path();
+        let smite_dir = &args.smite_dir;
+
+        // Keep a predictable order for operator readability and stable JSON output.
+        let mut checks = vec![
+            DoctorCheck::new("x86_64 architecture", check_architecture()),
+            DoctorCheck::new(
+                "CPU virtualization enabled (vmx/svm)",
+                check_cpu_virtualization_enabled(),
+            ),
+            DoctorCheck::new("/dev/kvm accessible", check_kvm_access()),
+            DoctorCheck::new("Docker daemon reachable", check_docker_daemon()),
+            DoctorCheck::new("AFL++ built with Nyx support", check_libnyx(aflpp_root)),
+            DoctorCheck::new("VMware backdoor enabled", check_vmware_backdoor_enabled()),
+        ];
+
+        for &tool in AFL_TOOLS {
+            checks.push(DoctorCheck::new(
+                tool,
+                require_executable(&aflpp_root.join(tool)),
+            ));
+        }
+
+        for &tool in HOST_TOOLS {
+            checks.push(DoctorCheck::new(tool, require_tool_on_path(tool)));
+        }
+
+        for script in REQUIRED_SCRIPTS {
+            let path = smite_dir.join("scripts").join(script);
+            checks.push(DoctorCheck::new(
+                format!("script executable: scripts/{script}"),
+                require_executable(&path),
+            ));
+        }
+
+        for dockerfile in REQUIRED_DOCKERFILES {
+            let path = smite_dir.join(dockerfile);
+            checks.push(DoctorCheck::new(
+                format!("dockerfile present: {dockerfile}"),
+                require_exists(&path),
+            ));
+        }
+
+        let overall = checks.iter().all(|check| check.passed);
+        let report = DoctorReport { overall, checks };
+
+        if args.json {
+            // JSON output is used by CI or external tooling to surface failures.
+            let json =
+                serde_json::to_string_pretty(&report).expect("DoctorReport is always serializable");
+            println!("{json}");
+        } else {
+            print_human_report(&report);
+        }
+
+        report.overall
+    }
+}
+
+/// Prints a compact checklist report intended for interactive terminal use.
+fn print_human_report(report: &DoctorReport) {
+    for check in &report.checks {
+        match &check.reason {
+            None => println!("[ok] {}", check.name),
+            Some(reason) => println!("[fail] {}: {reason}", check.name),
+        }
+    }
+
+    let total = report.checks.len();
+    if report.overall {
+        println!("\nsmitebot doctor: all {total} checks passed");
+    } else {
+        let failed = report.checks.iter().filter(|check| !check.passed).count();
+        println!("\nsmitebot doctor: {failed} of {total} checks failed");
+    }
+}
+
+/// Verifies that the host architecture is supported by Nyx mode.
+fn check_architecture() -> Result<(), CheckFailure> {
+    let arch = std::env::consts::ARCH;
+    if arch == "x86_64" {
+        Ok(())
+    } else {
+        Err(CheckFailure::UnsupportedArchitecture(arch.to_string()))
+    }
+}
+
+/// Checks for CPU virtualization flags required by KVM acceleration.
+fn check_cpu_virtualization_enabled() -> Result<(), CheckFailure> {
+    let path = Path::new("/proc/cpuinfo");
+    let cpuinfo = fs::read_to_string(path).map_err(|e| CheckFailure::io(path, e))?;
+
+    let has_flag = cpuinfo
+        .split_whitespace()
+        .any(|flag| flag == "vmx" || flag == "svm");
+
+    if has_flag {
+        Ok(())
+    } else {
+        Err(CheckFailure::MissingCpuVirtualization)
+    }
+}
+
+/// Verifies that `/dev/kvm` exists and is openable by the current user.
+fn check_kvm_access() -> Result<(), CheckFailure> {
+    let path = Path::new("/dev/kvm");
+    require_exists(path)?;
+    fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .map_err(|e| CheckFailure::io(path, e))?;
+    Ok(())
+}
+
+/// Checks that the Docker CLI can reach a running Docker daemon.
+fn check_docker_daemon() -> Result<(), CheckFailure> {
+    require_tool_on_path("docker")?;
+
+    let output = Command::new("docker")
+        .args(["version", "--format", "{{.Server.Version}}"])
+        .output()
+        .map_err(|e| CheckFailure::Command {
+            command: "docker version".to_string(),
+            detail: e.to_string(),
+        })?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(CheckFailure::Command {
+            command: "docker version".to_string(),
+            detail: command_failure_detail(&output),
+        })
+    }
+}
+
+/// Checks whether `libnyx.so` exists under the AFL++ root used for fuzzing.
+fn check_libnyx(aflpp_root: &Path) -> Result<(), CheckFailure> {
+    if aflpp_root.join("libnyx.so").exists() {
+        Ok(())
+    } else {
+        Err(CheckFailure::LibnyxNotFound)
+    }
+}
+
+/// Checks whether the KVM `VMware` backdoor needed by Nyx is enabled.
+fn check_vmware_backdoor_enabled() -> Result<(), CheckFailure> {
+    let path = Path::new("/sys/module/kvm/parameters/enable_vmware_backdoor");
+    let contents = fs::read_to_string(path).map_err(|e| CheckFailure::io(path, e))?;
+
+    if contents.trim().eq_ignore_ascii_case("y") {
+        Ok(())
+    } else {
+        Err(CheckFailure::VMwareBackdoorDisabled)
+    }
+}
+
+/// Returns success only when the path exists.
+fn require_exists(path: &Path) -> Result<(), CheckFailure> {
+    if path.exists() {
+        Ok(())
+    } else {
+        Err(CheckFailure::MissingPath(path.to_path_buf()))
+    }
+}
+
+/// Returns success only when the path exists and has an executable bit set.
+fn require_executable(path: &Path) -> Result<(), CheckFailure> {
+    require_exists(path)?;
+    if is_executable(path) {
+        Ok(())
+    } else {
+        Err(CheckFailure::NotExecutable(path.to_path_buf()))
+    }
+}
+
+/// Returns success when a tool is executable on `PATH`.
+fn require_tool_on_path(tool: &str) -> Result<(), CheckFailure> {
+    if find_in_path(tool).is_some() {
+        Ok(())
+    } else {
+        Err(CheckFailure::ToolNotFound(tool.to_string()))
+    }
+}
+
+/// Builds a useful failure detail from a completed command.
+fn command_failure_detail(output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = stderr.trim();
+    let stdout = stdout.trim();
+
+    match (stderr, stdout) {
+        ("", "") => output.status.to_string(),
+        ("", out) => format!("{} ({out})", output.status),
+        (err, _) => format!("{} ({err})", output.status),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn require_exists_reports_missing_path() {
+        let path = Path::new("/definitely/not/a/smitebot/path");
+        let err = require_exists(path).unwrap_err();
+        assert_eq!(err.to_string(), "/definitely/not/a/smitebot/path not found");
+    }
+
+    #[test]
+    fn require_executable_rejects_non_executable_file() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("tool");
+        fs::write(&path, "#!/bin/sh\n").unwrap();
+
+        let err = require_executable(&path).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            format!("{} not executable", path.display())
+        );
+    }
+
+    #[test]
+    fn require_executable_finds_afl_tool_under_aflpp_root() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let tool_path = tempdir.path().join("afl-fuzz");
+        fs::write(&tool_path, "#!/bin/sh\n").unwrap();
+        // Force executable permissions so the test doesn't depend on umask defaults.
+        let mut perms = fs::metadata(&tool_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&tool_path, perms).unwrap();
+
+        assert!(require_executable(&tempdir.path().join("afl-fuzz")).is_ok());
+    }
+
+    #[test]
+    fn doctor_report_json_is_machine_readable() {
+        let report = DoctorReport {
+            overall: false,
+            checks: vec![
+                DoctorCheck::new("check-a", Ok(())),
+                DoctorCheck::new("check-b", Err(CheckFailure::MissingCpuVirtualization)),
+            ],
+        };
+
+        let json = serde_json::to_string(&report).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["overall"], false);
+        assert_eq!(parsed["checks"][0]["name"], "check-a");
+        assert!(parsed["checks"][0].get("reason").is_none());
+        assert_eq!(parsed["checks"][1]["passed"], false);
+        assert_eq!(
+            parsed["checks"][1]["reason"],
+            "neither vmx nor svm flag found in /proc/cpuinfo"
+        );
+    }
+
+    #[test]
+    fn command_failure_detail_prefers_stderr() {
+        let output = output_with("stdout msg", "stderr msg");
+        assert_eq!(
+            command_failure_detail(&output),
+            "exit status: 1 (stderr msg)"
+        );
+    }
+
+    #[test]
+    fn command_failure_detail_uses_stdout_if_stderr_empty() {
+        let output = output_with("stdout msg", "");
+        assert_eq!(
+            command_failure_detail(&output),
+            "exit status: 1 (stdout msg)"
+        );
+    }
+
+    #[test]
+    fn command_failure_detail_handles_no_output() {
+        let output = output_with("", "");
+        assert_eq!(command_failure_detail(&output), "exit status: 1");
+    }
+
+    fn output_with(stdout: &str, stderr: &str) -> std::process::Output {
+        use std::os::unix::process::ExitStatusExt;
+        use std::process::ExitStatus;
+
+        // Build a synthetic Output so tests don't rely on executing external commands.
+        std::process::Output {
+            status: ExitStatus::from_raw(1 << 8),
+            stdout: stdout.as_bytes().to_vec(),
+            stderr: stderr.as_bytes().to_vec(),
+        }
+    }
+}

--- a/smitebot/src/main.rs
+++ b/smitebot/src/main.rs
@@ -1,0 +1,36 @@
+//! `smitebot` command-line interface.
+
+mod commands;
+mod utils;
+
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand};
+
+use commands::{DoctorArgs, DoctorCommand};
+
+#[derive(Debug, Parser)]
+#[command(name = "smitebot", version, about = "Smite campaign manager")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Validate host prerequisites for running Smite campaigns.
+    Doctor(DoctorArgs),
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    let success = match cli.command {
+        Commands::Doctor(args) => DoctorCommand::execute(&args),
+    };
+
+    if success {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}

--- a/smitebot/src/utils.rs
+++ b/smitebot/src/utils.rs
@@ -1,0 +1,77 @@
+//! Small filesystem helpers shared across smitebot commands.
+
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Returns true if `path` exists and has at least one executable bit set.
+pub fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::metadata(path).is_ok_and(|metadata| metadata.permissions().mode() & 0o111 != 0)
+}
+
+/// Finds an executable named `tool` on the process `PATH`.
+pub fn find_in_path(tool: &str) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    find_in_path_with_path(tool, &path_var)
+}
+
+/// Finds an executable tool using an explicit PATH value, mainly for tests.
+fn find_in_path_with_path(tool: &str, path_var: &OsStr) -> Option<PathBuf> {
+    std::env::split_paths(path_var)
+        .map(|dir| dir.join(tool))
+        .find(|candidate| candidate.is_file() && is_executable(candidate))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+
+    #[test]
+    fn find_in_path_with_path_finds_existing_executable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let binary_path = tempdir.path().join("afl-fuzz");
+        fs::write(&binary_path, "#!/bin/sh\n").unwrap();
+        // Ensure the test binary is executable regardless of umask defaults.
+        let mut perms = fs::metadata(&binary_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&binary_path, perms).unwrap();
+
+        let path_value = OsString::from(tempdir.path());
+        let found = find_in_path_with_path("afl-fuzz", &path_value).unwrap();
+        assert_eq!(found, binary_path);
+    }
+
+    #[test]
+    fn find_in_path_with_path_ignores_non_executable_file() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let binary_path = tempdir.path().join("afl-fuzz");
+        fs::write(&binary_path, "#!/bin/sh\n").unwrap();
+
+        let path_value = OsString::from(tempdir.path());
+        let found = find_in_path_with_path("afl-fuzz", &path_value);
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn is_executable_detects_permission_bits() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("tool");
+        fs::write(&path, "#!/bin/sh\n").unwrap();
+
+        assert!(!is_executable(&path));
+
+        // Flip the executable bit explicitly to validate the permission check.
+        let mut perms = fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&path, perms).unwrap();
+
+        assert!(is_executable(&path));
+    }
+}

--- a/workloads/cln/Dockerfile
+++ b/workloads/cln/Dockerfile
@@ -87,6 +87,7 @@ COPY smite/ smite/
 COPY smite-ir/ smite-ir/
 COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
+COPY smitebot/ smitebot/
 COPY smite-scenarios/ smite-scenarios/
 RUN set -eu; for f in smite-scenarios/src/bin/cln_*.rs; do \
         TARGET_MAP_SIZE=$(cat /tmp/total-map-size) \

--- a/workloads/cln/Dockerfile.coverage
+++ b/workloads/cln/Dockerfile.coverage
@@ -84,6 +84,7 @@ COPY smite/ smite/
 COPY smite-ir/ smite-ir/
 COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
+COPY smitebot/ smitebot/
 COPY smite-scenarios/ smite-scenarios/
 RUN cargo build -p smite-scenarios --bin cln_${SCENARIO} --release
 

--- a/workloads/eclair/Dockerfile
+++ b/workloads/eclair/Dockerfile
@@ -67,6 +67,7 @@ COPY smite/ smite/
 COPY smite-ir/ smite-ir/
 COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
+COPY smitebot/ smitebot/
 COPY smite-scenarios/ smite-scenarios/
 RUN set -eu; for f in smite-scenarios/src/bin/eclair_*.rs; do \
         TARGET_MAP_SIZE=$(cat /tmp/eclair-edge-count.txt) \

--- a/workloads/eclair/Dockerfile.coverage
+++ b/workloads/eclair/Dockerfile.coverage
@@ -54,6 +54,7 @@ COPY smite/ smite/
 COPY smite-ir/ smite-ir/
 COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
+COPY smitebot/ smitebot/
 COPY smite-scenarios/ smite-scenarios/
 RUN cargo build -p smite-scenarios --bin eclair_${SCENARIO} --release
 

--- a/workloads/ldk/Dockerfile
+++ b/workloads/ldk/Dockerfile
@@ -67,6 +67,7 @@ COPY smite/ smite/
 COPY smite-ir/ smite-ir/
 COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
+COPY smitebot/ smitebot/
 COPY smite-scenarios/ smite-scenarios/
 RUN set -eu; for f in smite-scenarios/src/bin/ldk_*.rs; do \
         TARGET_PATH=/ldk-wrapper/target/release/ldk-node-wrapper \

--- a/workloads/ldk/Dockerfile.coverage
+++ b/workloads/ldk/Dockerfile.coverage
@@ -55,6 +55,7 @@ COPY smite/ smite/
 COPY smite-ir/ smite-ir/
 COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
+COPY smitebot/ smitebot/
 COPY smite-scenarios/ smite-scenarios/
 ENV RUSTFLAGS=""
 RUN cargo build -p smite-scenarios --bin ldk_${SCENARIO} --release

--- a/workloads/lnd/Dockerfile
+++ b/workloads/lnd/Dockerfile
@@ -68,6 +68,7 @@ COPY smite/ smite/
 COPY smite-ir/ smite-ir/
 COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
+COPY smitebot/ smitebot/
 COPY smite-scenarios/ smite-scenarios/
 RUN set -eu; for f in smite-scenarios/src/bin/lnd_*.rs; do \
         TARGET_PATH=/lnd/cmd/lnd/lnd \

--- a/workloads/lnd/Dockerfile.coverage
+++ b/workloads/lnd/Dockerfile.coverage
@@ -54,6 +54,7 @@ COPY smite/ smite/
 COPY smite-ir/ smite-ir/
 COPY smite-ir-mutator/ smite-ir-mutator/
 COPY smite-nyx-sys/ smite-nyx-sys/
+COPY smitebot/ smitebot/
 COPY smite-scenarios/ smite-scenarios/
 RUN cargo build -p smite-scenarios --bin lnd_${SCENARIO} --release
 


### PR DESCRIPTION
## Summary
This PR introduces the first working `smitebot` command: `doctor`.

It adds `smitebot` crate and implements prerequisite checks needed before running Smite campaigns, with both human and machine readable(JSON) output.

## What’s included
- Add `smitebot` as a workspace member.
- Add `smitebot` crate dependencies (`clap`, `serde`, `serde_json`, `thiserror`).
- Implement `smitebot doctor` command (no stub-only command surface).
- Implement `--json` output for CI/machine parsing.
- Return non-zero exit code when any check fails.
- Add focused unit tests for report logic/path helpers/JSON shape.
- Add concise README docs, including install + direct `smitebot doctor` usage.

## Checks implemented
- `x86_64` architecture
- `/dev/kvm` accessible
- Docker daemon reachable (`docker info`)
- AFL++ tools on PATH:
  - `afl-fuzz`
  - `afl-cmin`
  - `afl-tmin`
  - `afl-whatsup`
- Nyx packer `hget` presence
- `libnyx.so` discoverable via `LD_LIBRARY_PATH`
- VMware backdoor enabled
- Required Smite scripts exist and are executable

## Validation
```bash
cargo fmt --all --check
cargo clippy -p smitebot --all-targets -- -D warnings
cargo test -p smitebot
cargo run -p smitebot -- doctor
cargo run -p smitebot -- doctor --json
```
Ref. #70 