### PR TITLE
smite-scenarios: warm up and freeze Eclair's JIT before the snapshot

### DIFF
--- a/smite-scenarios/src/bin/eclair_ir.rs
+++ b/smite-scenarios/src/bin/eclair_ir.rs
@@ -1,9 +1,9 @@
 //! Eclair IR fuzzing scenario binary.
 
 use smite::scenarios::smite_run;
-use smite_scenarios::scenarios::{IrScenario, PostInitSetup};
+use smite_scenarios::scenarios::{EclairWarmupSetup, IrScenario};
 use smite_scenarios::targets::EclairTarget;
 
 fn main() -> std::process::ExitCode {
-    smite_run::<IrScenario<EclairTarget, PostInitSetup>>()
+    smite_run::<IrScenario<EclairTarget, EclairWarmupSetup>>()
 }

--- a/smite-scenarios/src/scenarios.rs
+++ b/smite-scenarios/src/scenarios.rs
@@ -10,7 +10,7 @@ pub use encrypted_bytes::EncryptedBytesScenario;
 pub use init::InitScenario;
 pub use ir::IrScenario;
 pub use noise::NoiseScenario;
-pub use setup::{PostInitSetup, REGTEST_CHAIN_HASH, SnapshotSetup};
+pub use setup::{EclairWarmupSetup, PostInitSetup, REGTEST_CHAIN_HASH, SnapshotSetup};
 use smite::scenarios::ScenarioError;
 
 use std::time::Duration;

--- a/smite-scenarios/src/scenarios/setup.rs
+++ b/smite-scenarios/src/scenarios/setup.rs
@@ -2,13 +2,17 @@
 
 use std::time::Duration;
 
-use smite::bolt::{Init, InitTlvs, Message};
+use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+use smite::bolt::{
+    ChannelId, Error as ErrorMessage, Init, InitTlvs, Message, OpenChannel, OpenChannelTlvs,
+};
 use smite::noise::NoiseConnection;
 use smite::scenarios::ScenarioError;
+use smite_ir::operation::ChannelTypeVariant;
 
 use super::{handshake_with_target, ping_pong};
 use crate::executor::ProgramContext;
-use crate::targets::{INITIAL_BLOCKS, Target};
+use crate::targets::{EclairTarget, INITIAL_BLOCKS, Target};
 
 /// Bitcoin regtest genesis hash (in BOLT 2 network byte order).
 pub const REGTEST_CHAIN_HASH: [u8; 32] = [
@@ -77,22 +81,169 @@ fn init_for_single_funded(received: &Init) -> Init {
     }
 }
 
+/// Fixed feerate (sat/kW) for warmup `open_channel` messages. 2500 sat/kW
+/// (~10 sat/vB) is comfortably inside every target's accepted range.
+const WARMUP_FEERATE_PER_KW: u32 = 2500;
+
+/// Fixed funding amount (sat) for warmup `open_channel` messages.
+const WARMUP_FUNDING_SATOSHIS: u64 = 100_000;
+
+/// Derives the six public keys an `open_channel` requires from fixed secrets.
+fn warmup_channel_keys() -> [PublicKey; 6] {
+    let secp = Secp256k1::new();
+    let secrets: [[u8; 32]; 6] = [
+        [0x21; 32], [0x22; 32], [0x23; 32], [0x24; 32], [0x25; 32], [0x26; 32],
+    ];
+    secrets.map(|s| {
+        let sk = SecretKey::from_slice(&s).expect("valid warmup secret");
+        PublicKey::from_secret_key(&secp, &sk)
+    })
+}
+
+/// Builds a spec-valid single-funded `open_channel` for warmup traffic.
+///
+/// The parameters are fixed and known-good; only `temporary_channel_id` changes
+/// per iteration.
+fn warmup_open_channel(temporary_channel_id: ChannelId, keys: &[PublicKey; 6]) -> OpenChannel {
+    OpenChannel {
+        chain_hash: REGTEST_CHAIN_HASH,
+        temporary_channel_id,
+        funding_satoshis: WARMUP_FUNDING_SATOSHIS,
+        push_msat: 0,
+        dust_limit_satoshis: 546,
+        max_htlc_value_in_flight_msat: WARMUP_FUNDING_SATOSHIS * 1000,
+        channel_reserve_satoshis: 1000,
+        htlc_minimum_msat: 1,
+        feerate_per_kw: WARMUP_FEERATE_PER_KW,
+        to_self_delay: 144,
+        max_accepted_htlcs: 483,
+        funding_pubkey: keys[0],
+        revocation_basepoint: keys[1],
+        payment_basepoint: keys[2],
+        delayed_payment_basepoint: keys[3],
+        htlc_basepoint: keys[4],
+        first_per_commitment_point: keys[5],
+        channel_flags: 0x00,
+        tlvs: OpenChannelTlvs {
+            // Always send the TLV: a zero-length value is the BOLT 2 opt-out
+            // signal when option_upfront_shutdown_script is negotiated (which
+            // Eclair advertises and we echo). Omitting it is a protocol
+            // violation that makes Eclair drop the connection.
+            upfront_shutdown_script: Some(Vec::new()),
+            channel_type: Some(ChannelTypeVariant::Anchors.encode()),
+        },
+    }
+}
+
+/// Derives a distinct, non-zero `temporary_channel_id` for warmup open `seed`.
+///
+/// Each open needs a distinct id or Eclair rejects the duplicate. The `0x01`
+/// fill keeps it non-zero: BOLT 1 reserves the all-zero channel id for "fail
+/// all channels", which would make our per-channel abort drop the connection.
+fn warmup_temp_channel_id(seed: u64) -> ChannelId {
+    let mut bytes = [0x01u8; 32];
+    bytes[..8].copy_from_slice(&seed.to_be_bytes());
+    ChannelId::new(bytes)
+}
+
+/// Establishes a Noise connection and completes the `init` exchange for the
+/// single-funded `open_channel` flow, returning a connection ready to carry
+/// channel messages along with the target's `Init`.
+fn establish_connection<T: Target>(target: &T) -> Result<(NoiseConnection, Init), ScenarioError> {
+    let (mut conn, target_init) = handshake_with_target(target, TIMEOUT)?;
+
+    // Echo features but strip the bits that would take us off the single-funded
+    // `open_channel` path this setup is built for.
+    let our_init = init_for_single_funded(&target_init);
+    conn.send_message(&Message::Init(our_init).encode())?;
+
+    // Drain any post-init noise so the caller starts from a clean connection.
+    ping_pong(&mut conn)?;
+
+    Ok((conn, target_init))
+}
+
+/// Reason string in the `error` that retires a warmup channel.
+const WARMUP_ABORT_REASON: &str = "warmup done";
+
+/// Sends one warmup `open_channel` and waits for the target to accept it.
+///
+/// Both halves are required. Waiting: Eclair handles opens in one
+/// `OpenChannelInterceptor` actor per peer and answers anything arriving while
+/// it is busy with `error("concurrent request rejected")`, so pipelined opens
+/// warm nothing. Replying `error` on `accept_channel`: that closes the channel
+/// actor and frees the pending-channel slot, which is otherwise only released
+/// on disconnect, so a long-lived connection would hit Eclair's limit
+/// (`max-total-pending-channels-private-nodes`, default 99).
+///
+/// A rejection is fatal rather than retried: it means the channel path never
+/// ran, and the cause (channel type, feature bits, a limit) is not transient.
+fn warmup_open(
+    conn: &mut NoiseConnection,
+    temp_id: ChannelId,
+    keys: &[PublicKey; 6],
+) -> Result<(), ScenarioError> {
+    let open = warmup_open_channel(temp_id, keys);
+    conn.send_message(&Message::OpenChannel(open).encode())?;
+
+    loop {
+        match Message::decode(&conn.recv_message()?)? {
+            Message::AcceptChannel(accept) if accept.temporary_channel_id == temp_id => {
+                let abort = ErrorMessage::for_channel(temp_id, WARMUP_ABORT_REASON);
+                conn.send_message(&Message::Error(abort).encode())?;
+                return Ok(());
+            }
+            Message::Error(err) if err.channel_id == temp_id => {
+                return Err(ScenarioError::Protocol(format!(
+                    "target rejected a warmup open_channel: {}",
+                    String::from_utf8_lossy(&err.data)
+                )));
+            }
+            // A connection-level error tears down every channel, so there is
+            // nothing left to warm on this connection.
+            Message::Error(err) if err.channel_id == ChannelId::ALL => {
+                return Err(ScenarioError::Protocol(format!(
+                    "target sent a connection-level error during warmup: {}",
+                    String::from_utf8_lossy(&err.data)
+                )));
+            }
+            // Warnings, gossip and replies for retired channels are noise here.
+            _ => {}
+        }
+    }
+}
+
+/// Drives `iterations` `open_channel` -> `accept_channel` exchanges to warm up a
+/// JVM target before the snapshot, so `HotSpot` JIT-compiles the channel path.
+///
+/// Runs on a throwaway connection, never the snapshot connection. Exchanges are
+/// sequential and each is retired with an `error`; see [`warmup_open`] for why.
+fn warmup<T: Target>(target: &T, iterations: usize) -> Result<(), ScenarioError> {
+    log::info!("Warming up target with {iterations} open_channel exchanges");
+    let keys = warmup_channel_keys();
+    let (mut conn, _) = establish_connection(target)?;
+
+    for seed in 0..iterations as u64 {
+        warmup_open(&mut conn, warmup_temp_channel_id(seed), &keys)?;
+    }
+
+    // Flush the last abort so every warmup channel is retired before the
+    // connection goes away.
+    ping_pong(&mut conn)?;
+    drop(conn);
+
+    log::info!("Warmup complete: {iterations} open_channel exchanges");
+    Ok(())
+}
+
 /// Setup that snapshots just after the Noise handshake and init exchange are
 /// complete.
 pub struct PostInitSetup;
 
 impl<T: Target> SnapshotSetup<T> for PostInitSetup {
     fn setup(target: &T) -> Result<(NoiseConnection, ProgramContext), ScenarioError> {
-        let (mut conn, target_init) = handshake_with_target(target, TIMEOUT)?;
-
-        // Echo features but strip the bits that would take us off the
-        // single-funded `open_channel` path this setup is built for.
-        let our_init = init_for_single_funded(&target_init);
-        conn.send_message(&Message::Init(our_init).encode())?;
-
-        // Drain any remaining post-init noise so the snapshot starts with a
-        // clean connection.
-        ping_pong(&mut conn)?;
+        // Establish the pristine connection the fuzzer reuses across runs.
+        let (conn, target_init) = establish_connection(target)?;
 
         let context = ProgramContext {
             target_pubkey: *target.pubkey(),
@@ -105,5 +256,34 @@ impl<T: Target> SnapshotSetup<T> for PostInitSetup {
         };
 
         Ok((conn, context))
+    }
+}
+
+/// Default number of warmup `open_channel` exchanges for [`EclairWarmupSetup`].
+///
+/// Overridable via `SMITE_WARMUP_ITERATIONS`; zero skips warmup entirely.
+const ECLAIR_WARMUP_ITERATIONS: usize = 200;
+
+/// [`PostInitSetup`] preceded by a JVM warmup pass; used for Eclair.
+///
+/// Before the snapshot it drives `open_channel` exchanges so `HotSpot`
+/// JIT-compiles Eclair's channel path, then freezes the JIT so no compiler
+/// threads run during fuzzing.
+pub struct EclairWarmupSetup;
+
+impl SnapshotSetup<EclairTarget> for EclairWarmupSetup {
+    fn setup(target: &EclairTarget) -> Result<(NoiseConnection, ProgramContext), ScenarioError> {
+        // `SMITE_WARMUP_ITERATIONS` overrides the default without recompiling.
+        let iterations = std::env::var("SMITE_WARMUP_ITERATIONS")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(ECLAIR_WARMUP_ITERATIONS);
+        if iterations > 0 {
+            warmup(target, iterations)?;
+            target.freeze_jit()?;
+        }
+
+        // Reuse the generic post-init setup for the snapshot connection + context.
+        PostInitSetup::setup(target)
     }
 }

--- a/smite-scenarios/src/targets/eclair.rs
+++ b/smite-scenarios/src/targets/eclair.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::process::{Command, Stdio};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use bitcoin::secp256k1;
 use serde::Deserialize;
@@ -20,6 +20,18 @@ use super::{Target, TargetError, check_crash_log};
 
 /// API password for Eclair's REST API.
 const API_PASSWORD: &str = "fuzzpass";
+
+/// Upper bound on how long to wait for the JVM's JIT compile queue to drain
+/// after warmup before giving up and freezing anyway.
+const JIT_DRAIN_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// How often to poll `jcmd Compiler.queue` while waiting for it to drain.
+const JIT_DRAIN_POLL: Duration = Duration::from_millis(150);
+
+/// Number of consecutive idle polls required before declaring the compile queue
+/// drained, so we don't stop during a transient lull while Eclair is still
+/// feeding the compiler.
+const JIT_DRAIN_CONFIRMATIONS: u32 = 3;
 
 /// Configuration for the Eclair target.
 pub struct EclairConfig {
@@ -125,9 +137,22 @@ impl EclairTarget {
             cmd.env("LD_PRELOAD", handler);
         }
 
-        cmd.arg(format!("-Declair.datadir={}", eclair_dir.display()))
-            .stdout(Stdio::null())
-            .stderr(Stdio::null());
+        // JVM tuning options for eclair-node.sh, applied for the lifetime of the
+        // Eclair process. Replaces JAVA_OPTS outright, so it must restate any
+        // defaults from the workload's init.sh it still wants.
+        if let Ok(opts) = std::env::var("SMITE_ECLAIR_JAVA_OPTS") {
+            cmd.env("JAVA_OPTS", opts);
+        }
+
+        cmd.arg(format!("-Declair.datadir={}", eclair_dir.display()));
+
+        // Silence Eclair by default; inherit its stdio when we need to see JVM
+        // diagnostics such as -XX:+PrintCompilation output.
+        if std::env::var("SMITE_ECLAIR_LOG").is_ok() {
+            cmd.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+        } else {
+            cmd.stdout(Stdio::null()).stderr(Stdio::null());
+        }
 
         let eclair = ManagedProcess::spawn(&mut cmd, "eclair")?;
 
@@ -192,6 +217,87 @@ impl EclairTarget {
             .map_err(|e| TargetError::StartFailed(format!("failed to parse pubkey: {e}")))?;
 
         Ok((pubkey, info.block_height))
+    }
+
+    /// Runs `jcmd <eclair-jvm-pid> <args...>` and returns its stdout on success.
+    fn run_jcmd(&self, args: &[&str]) -> Result<String, String> {
+        let java_home = std::env::var("JAVA_HOME").unwrap_or_else(|_| "/opt/java/openjdk".into());
+        let out = Command::new(format!("{java_home}/bin/jcmd"))
+            .arg(self.eclair.pid().to_string())
+            .args(args)
+            .output()
+            .map_err(|e| format!("failed to run jcmd: {e}"))?;
+        if out.status.success() {
+            Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+        } else {
+            Err(format!(
+                "jcmd {} failed (status {}): {}",
+                args.join(" "),
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim()
+            ))
+        }
+    }
+
+    /// Polls `jcmd Compiler.queue` until the compiler is idle for
+    /// [`JIT_DRAIN_CONFIRMATIONS`] consecutive polls, or [`JIT_DRAIN_TIMEOUT`]
+    /// elapses. Idle = the output lists no in-flight `CompilerThread` and no
+    /// queued `Class::method` (`::`).
+    fn wait_for_compiler_idle(&self) {
+        let deadline = Instant::now() + JIT_DRAIN_TIMEOUT;
+        let mut consecutive_idle = 0u32;
+        loop {
+            let idle = match self.run_jcmd(&["Compiler.queue"]) {
+                Ok(out) => !out.contains("CompilerThread") && !out.contains("::"),
+                // If we can't query the queue we can't confirm idle; keep trying
+                // until the timeout rather than freezing a possibly-busy compiler.
+                Err(e) => {
+                    log::debug!("Compiler.queue poll failed: {e}");
+                    false
+                }
+            };
+
+            if idle {
+                consecutive_idle += 1;
+                if consecutive_idle >= JIT_DRAIN_CONFIRMATIONS {
+                    log::info!("JIT compile queue drained");
+                    return;
+                }
+            } else {
+                consecutive_idle = 0;
+            }
+
+            if Instant::now() >= deadline {
+                log::warn!("timed out waiting for JIT compile queue to drain; freezing anyway");
+                return;
+            }
+            std::thread::sleep(JIT_DRAIN_POLL);
+        }
+    }
+
+    /// Waits for the compile queue to drain, then freezes the JIT via a catch-all
+    /// `Exclude` compiler directive (`jcmd`). This blocks further compilation
+    /// while keeping warmed code installed (verified: no deopt), so no compiler
+    /// threads run during fuzzing. Draining first is essential — freezing with
+    /// methods still queued would leave them interpreted.
+    ///
+    /// `eclair-node.sh` `exec`s the JVM, so `self.eclair.pid()` is the JVM pid.
+    /// Best-effort: jcmd failures are logged, not propagated.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error only if writing the directive file fails.
+    pub fn freeze_jit(&self) -> Result<(), TargetError> {
+        self.wait_for_compiler_idle();
+
+        // Catch-all exclude: block future JIT compilation of every method.
+        let directive = std::env::temp_dir().join("smite-jit-exclude-all.json");
+        fs::write(&directive, "[ { match: [\"*.*\"], Exclude: true } ]\n")?;
+        match self.run_jcmd(&["Compiler.directives_add", &directive.to_string_lossy()]) {
+            Ok(out) => log::info!("Froze JIT via jcmd: {}", out.trim()),
+            Err(e) => log::warn!("could not freeze JIT: {e}"),
+        }
+        Ok(())
     }
 }
 

--- a/workloads/eclair/Dockerfile
+++ b/workloads/eclair/Dockerfile
@@ -91,7 +91,11 @@ RUN cc -shared -fPIC -DENABLE_NYX -DNO_PT_NYX \
     smite-nyx-sys/src/jvm-crash-handler.c -o /jvm-crash-handler.so
 
 # Runtime image.
-FROM eclipse-temurin:21-jre
+#
+# Uses the full JDK (not -jre) so `jcmd` is available: after warmup the harness
+# runs `jcmd <pid> Compiler.directives_add` to freeze the JIT (block new
+# compilation while keeping warmed code) before the snapshot.
+FROM eclipse-temurin:21
 ARG SCENARIO
 
 # Install curl for Eclair readiness polling in EclairTarget::query_info().

--- a/workloads/eclair/init.sh
+++ b/workloads/eclair/init.sh
@@ -16,9 +16,11 @@ export SMITE_CRASH_HANDLER=/nyx-jvm-crash-handler.so
 # JVM tuning for Nyx fuzzing performance. JAVA_OPTS is picked up by
 # eclair-node.sh and passed to the JVM.
 #
-# -XX:TieredStopAtLevel=1: Use only the C1 JIT compiler, skipping C2 compilation
-#   entirely. C2 runs expensive optimizations in background threads which get
-#   repeated every time we restore the VM snapshot, reducing fuzzing speed.
+# -XX:TieredStopAtLevel=1: Use only the C1 JIT compiler, skipping C2. C2 measured
+#   ~28% fewer execs/sec here: its speculative optimizations are tuned to the
+#   fixed warmup path, so varied fuzzing inputs trip uncommon traps and deopt to
+#   the interpreter each restore. C1 doesn't speculate, staying robust across
+#   inputs with a more compact code cache.
 #
 # -javaagent: Coverage agent that instruments bytecode and writes edge counters
 #   to AFL shared memory via JNI.


### PR DESCRIPTION
Snapshot-restore fuzzing of Eclair started every iteration on a cold JVM, so the channel path ran interpreted. Add an Eclair-specific SnapshotSetup that, before the snapshot is taken:

- drives thousands of open_channel exchanges on throwaway connections so HotSpot JIT-compiles the channel path (batched under Eclair's pending- channel rate limit),
- waits for the compile queue to drain (polling jcmd Compiler.queue),
- freezes the JIT with a catch-all Exclude directive so no compiler threads run during fuzzing.

Keeps C1 only (-XX:TieredStopAtLevel=1): C2 measured ~28% slower here as its speculation deopts on varied fuzzing inputs. The runtime image switches to the full JDK for jcmd.

Warming the JVM before taking the snapshot increased steady-state fuzzing throughput from 2.3 to 3.9 execs/sec for or the following input, a 1.70× (69.6%) improvement. (I've used https://github.com/morehouse/smite/pull/160 to benchmark it).

We can see the JVM logs optimizing the code with:

```
docker run --rm \
           -v $PWD/input.bin:/input.bin \
           -e SMITE_INPUT=/input.bin \
           -e RUST_LOG=info \
           -e SMITE_ECLAIR_LOG=1 \
           -e SMITE_ECLAIR_JAVA_OPTS="-XX:TieredStopAtLevel=1 -XX:+PrintCompilation" \
           smite-eclair-ir /eclair-scenario > jvmlogs/raw.log 2>&1
```

<details><summary>Logs:</summary>

```
5430 9896       1       fr.acinq.eclair.wire.protocol.RecommendedFeeratesTlv$CommitmentFeerateRange::equals (113 bytes)
5442 9897       1       scala.runtime.RichLong::self (8 bytes)
5457 9898       1       scala.collection.immutable.Map$Map2$$anon$3::nextResult (2 bytes)
5458 9899       1       scala.math.Ordering::gt$ (7 bytes)
5458 9900       1       scala.math.Ordering::gt (16 bytes)
5476 9901       1       scala.collection.immutable.NumericRange::isEmpty (21 bytes)
5476 9902       1       scala.collection.immutable.NumericRange::isInclusive (5 bytes)
5486 9903       1       sun.nio.ch.SocketChannelImpl::isNetSocket (26 bytes)
INFO  [smite_scenarios::scenarios::setup] Warmup complete
5836 9904       1       fr.acinq.eclair.blockchain.bitcoind.zmq.ZMQActor::context (5 bytes)
5985 9905       1       fr.acinq.eclair.blockchain.bitcoind.zmq.ZMQActor::subscriber (5 bytes)
6055 9906       1       scala.Symbol$::keyFromValue (12 bytes)
6115 9907       1       fr.acinq.eclair.blockchain.bitcoind.zmq.ZMQActor::ec (5 bytes)
INFO  [smite_scenarios::targets::eclair] JIT compile queue drained
6185 9908       1       scala.UniquenessCache::unapply (6 bytes)
INFO  [smite_scenarios::targets::eclair] Froze JIT via jcmd: 56:
1 compiler directives added
### Excluding generation of native wrapper: static sun.nio.ch.IOUtil::fdVal
made not compilable on level 1  sun.nio.ch.IOUtil::fdVal   excluded by CompileCommand
### Excluding compile: fr.acinq.eclair.Features$ChannelRangeQueries$::hashCode
made not compilable on level 1  fr.acinq.eclair.Features$ChannelRangeQueries$::hashCode (3 bytes)   excluded by CompileCommand
INFO  [smite::scenarios] Scenario initialized! Executing input...
INFO  [smite::runners] Reading input from "/input.bin"
### Excluding compile: zmq.socket.pubsub.XSub::xrecv
```

</details> 

<details><summary>Input</summary>

```
v0 = LoadPrivateKey(0x1111111111111111111111111111111111111111111111111111111111111111)
v1 = DerivePoint(v0)
v2 = LoadPrivateKey(0x1212121212121212121212121212121212121212121212121212121212121212)
v3 = DerivePoint(v2)
v4 = LoadPrivateKey(0x1313131313131313131313131313131313131313131313131313131313131313)
v5 = DerivePoint(v4)
v6 = LoadPrivateKey(0x1414141414141414141414141414141414141414141414141414141414141414)
v7 = DerivePoint(v6)
v8 = LoadPrivateKey(0x1515151515151515151515151515151515151515151515151515151515151515)
v9 = DerivePoint(v8)
v10 = LoadPrivateKey(0x1616161616161616161616161616161616161616161616161616161616161616)
v11 = DerivePoint(v10)
v12 = LoadChainHashFromContext()
v13 = LoadChannelId(0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a)
v14 = LoadAmount(100000)
v15 = LoadAmount(0)
v16 = LoadAmount(546)
v17 = LoadAmount(100000000)
v18 = LoadAmount(1000)
v19 = LoadAmount(1)
v20 = LoadFeeratePerKw(2500)
v21 = LoadU16(144)
v22 = LoadU16(483)
v23 = LoadU8(0)
v24 = LoadShutdownScript(Empty)
v25 = LoadChannelType(Anchors)
v26 = BuildOpenChannel(v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v1, v3, v5, v7, v9, v11, v23, v24, v25)
v27 = SendOpenChannel(v26)
v28 = RecvAcceptChannel(v27)
v29 = ExtractFundingPubkey(v28)
v30 = CreateFundingTransaction(v1, v29, v14, v20)
v31 = SendFundingCreated(v30, v0, v13)
v32 = RecvFundingSigned(v31)
BroadcastTransaction(v30)
MineBlocks(8)
RecvChannelReady()
v36 = LoadPrivateKey(0x1717171717171717171717171717171717171717171717171717171717171717)
v37 = DerivePoint(v36)
v38 = LoadShortChannelId(0x0x0)
SendChannelReady{include_alias=false}(v32, v37, v38)
```


</details> 

<details><summary>Before</summary>

```
Smite Nyx benchmark
  target:      eclair/ir
  sharedir:    /tmp/smite-nyx
  input size:  405 bytes
  iterations:  100
  repeats:     6

  run 1/6:
  snapshot creation (first exec): 442.67 ms
  steady-state (snapshot restore + target run):
    execs/sec: 2.3
    wall time: 43.754 s
    latency:   min 426.71 ms  mean 437.54 ms  median 435.11 ms  p99 458.89 ms  max 500.49 ms
    input execution: mean 426.27 ms  median 424.01 ms   (guest runtime)
    nyx overhead:    mean 11.27 ms  median 11.18 ms   (restore + reset + ipc; 28753 dirty pages/exec)
    non-normal results: 0 / 100

  run 2/6:
  snapshot creation (first exec): 426.26 ms
  steady-state (snapshot restore + target run):
    execs/sec: 2.4
    wall time: 41.146 s
    latency:   min 379.63 ms  mean 411.46 ms  median 401.53 ms  p99 492.16 ms  max 505.94 ms
    input execution: mean 400.11 ms  median 390.04 ms   (guest runtime)
    nyx overhead:    mean 11.35 ms  median 11.29 ms   (restore + reset + ipc; 28732 dirty pages/exec)
    non-normal results: 0 / 100

  run 3/6:
  snapshot creation (first exec): 462.03 ms
  steady-state (snapshot restore + target run):
    execs/sec: 2.2
    wall time: 44.492 s
    latency:   min 406.64 ms  mean 444.92 ms  median 439.64 ms  p99 536.15 ms  max 542.38 ms
    input execution: mean 433.44 ms  median 428.76 ms   (guest runtime)
    nyx overhead:    mean 11.48 ms  median 11.27 ms   (restore + reset + ipc; 28765 dirty pages/exec)
    non-normal results: 0 / 100

  run 4/6:
  snapshot creation (first exec): 541.80 ms
  steady-state (snapshot restore + target run):
    execs/sec: 2.3
    wall time: 43.949 s
    latency:   min 405.46 ms  mean 439.49 ms  median 423.15 ms  p99 529.56 ms  max 552.07 ms
    input execution: mean 427.76 ms  median 411.30 ms   (guest runtime)
    nyx overhead:    mean 11.73 ms  median 11.47 ms   (restore + reset + ipc; 28671 dirty pages/exec)
    non-normal results: 0 / 100

  run 5/6:
  snapshot creation (first exec): 515.63 ms
  steady-state (snapshot restore + target run):
    execs/sec: 2.3
    wall time: 42.919 s
    latency:   min 394.80 ms  mean 429.19 ms  median 418.29 ms  p99 523.86 ms  max 552.63 ms
    input execution: mean 417.55 ms  median 406.38 ms   (guest runtime)
    nyx overhead:    mean 11.64 ms  median 11.49 ms   (restore + reset + ipc; 28810 dirty pages/exec)
    non-normal results: 0 / 100

  run 6/6:
  snapshot creation (first exec): 539.49 ms
  steady-state (snapshot restore + target run):
    execs/sec: 2.3
    wall time: 43.982 s
    latency:   min 412.68 ms  mean 439.82 ms  median 425.83 ms  p99 547.89 ms  max 575.46 ms
    input execution: mean 427.70 ms  median 413.65 ms   (guest runtime)
    nyx overhead:    mean 12.12 ms  median 11.90 ms   (restore + reset + ipc; 28606 dirty pages/exec)
    non-normal results: 0 / 100

  aggregate over 6 runs:
    execs/sec: mean 2.3  stddev 0.1  min 2.2  max 2.4
    snapshot:  mean 487.98 ms
    latency (mean across runs):
      min 404.32 ms  mean 433.74 ms  median 423.92 ms  p99 514.75 ms  max 538.16 ms
    input execution (mean across runs): mean 422.14 ms  median 412.36 ms
    nyx overhead (mean across runs):     mean 11.60 ms  median 11.43 ms
    non-normal results: 0 / 600
```

</details> 

<details><summary>After</summary>

```
Smite Nyx benchmark
  target:      eclair/ir
  sharedir:    /tmp/smite-nyx
  input size:  405 bytes
  iterations:  100
  repeats:     8

  run 1/8:
  snapshot creation (first exec): 310.78 ms
  steady-state (snapshot restore + target run):
    execs/sec: 3.6
    wall time: 28.129 s
    latency:   min 267.64 ms  mean 281.29 ms  median 279.98 ms  p99 299.24 ms  max 311.10 ms
    input execution: mean 271.63 ms  median 270.80 ms   (guest runtime)
    nyx overhead:    mean 9.66 ms  median 9.50 ms   (restore + reset + ipc; 23478 dirty pages/exec)
    non-normal results: 0 / 100

  run 2/8:
  snapshot creation (first exec): 245.27 ms
  steady-state (snapshot restore + target run):
    execs/sec: 3.8
    wall time: 26.039 s
    latency:   min 228.98 ms  mean 260.39 ms  median 241.91 ms  p99 529.11 ms  max 539.95 ms
    input execution: mean 251.38 ms  median 233.55 ms   (guest runtime)
    nyx overhead:    mean 9.01 ms  median 8.65 ms   (restore + reset + ipc; 20396 dirty pages/exec)
    non-normal results: 0 / 100

  run 3/8:
  snapshot creation (first exec): 271.62 ms
  steady-state (snapshot restore + target run):
    execs/sec: 3.7
    wall time: 26.739 s
    latency:   min 249.17 ms  mean 267.39 ms  median 265.53 ms  p99 303.05 ms  max 303.55 ms
    input execution: mean 258.48 ms  median 256.52 ms   (guest runtime)
    nyx overhead:    mean 8.91 ms  median 8.84 ms   (restore + reset + ipc; 22011 dirty pages/exec)
    non-normal results: 0 / 100

  run 4/8:
  snapshot creation (first exec): 171.90 ms
  steady-state (snapshot restore + target run):
    execs/sec: 4.2
    wall time: 23.641 s
    latency:   min 203.86 ms  mean 236.41 ms  median 237.04 ms  p99 256.31 ms  max 259.80 ms
    input execution: mean 229.58 ms  median 230.32 ms   (guest runtime)
    nyx overhead:    mean 6.83 ms  median 6.66 ms   (restore + reset + ipc; 16397 dirty pages/exec)
    non-normal results: 0 / 100

  run 5/8:
  snapshot creation (first exec): 226.48 ms
  steady-state (snapshot restore + target run):
    execs/sec: 4.5
    wall time: 22.201 s
    latency:   min 214.69 ms  mean 222.01 ms  median 220.72 ms  p99 236.80 ms  max 238.02 ms
    input execution: mean 214.18 ms  median 212.95 ms   (guest runtime)
    nyx overhead:    mean 7.84 ms  median 7.74 ms   (restore + reset + ipc; 18998 dirty pages/exec)
    non-normal results: 0 / 100

  run 6/8:
  snapshot creation (first exec): 265.21 ms
  steady-state (snapshot restore + target run):
    execs/sec: 4.0
    wall time: 25.131 s
    latency:   min 237.48 ms  mean 251.31 ms  median 246.77 ms  p99 291.18 ms  max 293.20 ms
    input execution: mean 241.83 ms  median 237.33 ms   (guest runtime)
    nyx overhead:    mean 9.48 ms  median 9.38 ms   (restore + reset + ipc; 23779 dirty pages/exec)
    non-normal results: 0 / 100

  run 7/8:
  snapshot creation (first exec): 259.52 ms
  steady-state (snapshot restore + target run):
    execs/sec: 4.2
    wall time: 23.614 s
    latency:   min 222.55 ms  mean 236.13 ms  median 232.66 ms  p99 276.10 ms  max 276.50 ms
    input execution: mean 226.99 ms  median 223.75 ms   (guest runtime)
    nyx overhead:    mean 9.14 ms  median 9.11 ms   (restore + reset + ipc; 22798 dirty pages/exec)
    non-normal results: 0 / 100

  run 8/8:
  snapshot creation (first exec): 311.06 ms
  steady-state (snapshot restore + target run):
    execs/sec: 3.3
    wall time: 30.664 s
    latency:   min 283.79 ms  mean 306.64 ms  median 302.64 ms  p99 352.06 ms  max 356.74 ms
    input execution: mean 296.68 ms  median 293.30 ms   (guest runtime)
    nyx overhead:    mean 9.96 ms  median 9.59 ms   (restore + reset + ipc; 23136 dirty pages/exec)
    non-normal results: 0 / 100

  aggregate over 8 runs:
    execs/sec: mean 3.9  stddev 0.4  min 3.3  max 4.5
    snapshot:  mean 257.73 ms
    latency (mean across runs):
      min 238.52 ms  mean 257.70 ms  median 253.41 ms  p99 317.98 ms  max 322.36 ms
    input execution (mean across runs): mean 248.84 ms  median 244.81 ms
    nyx overhead (mean across runs):     mean 8.85 ms  median 8.68 ms
    non-normal results: 0 / 800
```


</details> 

### Target: eclair

## 1. Summary Statistics

| Target   |   Duration (h) |   n (Baseline) |   n (Exp.) |   Median Cov. (Baseline) |   Median Cov. (Exp.) |   Adj. p-value (Cov.) |   Â12 (Cov.) |   Median AUC (Baseline) |   Median AUC (Exp.) |   Adj. p-value (AUC) |   Â12 (AUC) |   Union Cov. (Baseline) |   Union Cov. (Exp.) |   Execs/s (Baseline) |   Execs/s (Exp.) |
|:---------|---------------:|---------------:|-----------:|-------------------------:|---------------------:|----------------------:|-------------:|------------------------:|--------------------:|---------------------:|------------:|------------------------:|--------------------:|---------------------:|-----------------:|
| eclair   |        1.99194 |             10 |         10 |                    10633 |              10963.7 |            0.00170625 |         0.92 |                 20857.5 |             21529.5 |          0.000246128 |        0.99 |                   11098 |               11627 |               17.165 |           46.165 |

#### Median Coverage Over Time

![eclair Time Series](https://github.com/user-attachments/assets/bbb65d99-47b5-4ff1-9685-3575bca993c9)

#### Distribution Comparisons

| Final Edge Coverage | Area Under Curve (Speed) |
|:---:|:---:|
| ![eclair Boxplot](https://github.com/user-attachments/assets/4f5167ef-74ef-43e1-b0ea-4fe8951bda28) | ![eclair AUC](https://github.com/user-attachments/assets/426832a3-db6e-45d0-9540-df845eea6772) |
