### PR TITLE
smite-ir: back `channel_announcement` with a real funding output

### DIFF
--- a/smite-ir/src/generators/channel_announcement.rs
+++ b/smite-ir/src/generators/channel_announcement.rs
@@ -1,20 +1,38 @@
 //! Generator for `channel_announcement` gossip message.
 
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 use super::Generator;
 use crate::builder::ProgramBuilder;
 use crate::{Operation, VariableType};
 
-/// Generates an unsolicited `channel_announcement` send.
+/// Generates an unsolicited `channel_announcement` send backed by a real
+/// funding output.
+///
+/// Emits instructions to:
+/// 1. Create, broadcast, and confirm a 2-of-2 P2WSH funding transaction
+/// 2. Look up the `short_channel_id` of the confirmed funding output
+/// 3. Build and send `channel_announcement`
+///
+/// The announced bitcoin keys are the ones committed to by the funding
+/// output's witness script, so the message can pass the on-chain UTXO
+/// validation that lightning implementations perform.
 #[derive(Clone, Copy)]
 pub struct ChannelAnnouncementGenerator;
+
+impl ChannelAnnouncementGenerator {
+    /// BOLT 2 caps `funding_satoshis` at 2^24-1 for non-wumbo channels, and we
+    /// only have so much wallet balance to spend.
+    pub const MAX_FUNDING_SATOSHIS: u64 = 16_777_215;
+
+    /// Bounded so that fees don't exhaust the wallet.
+    pub const MAX_FEERATE_PER_KW: u32 = 10_000;
+}
 
 impl Generator for ChannelAnnouncementGenerator {
     fn generate(&self, builder: &mut ProgramBuilder, rng: &mut impl Rng) {
         let features = builder.pick_variable(VariableType::Features, rng);
         let chain_hash = builder.pick_variable(VariableType::ChainHash, rng);
-        let scid = builder.pick_variable(VariableType::ShortChannelId, rng);
 
         // Use fresh private keys since channel_announcement validation
         // generally requires distinct keys.
@@ -23,12 +41,47 @@ impl Generator for ChannelAnnouncementGenerator {
         let bitcoin_sk_1 = builder.generate_fresh(VariableType::PrivateKey, rng);
         let bitcoin_sk_2 = builder.generate_fresh(VariableType::PrivateKey, rng);
 
+        // The funding output must pay to the same bitcoin keys the message
+        // announces, so derive the funding pubkeys instead of picking them.
+        let funding_pubkey_1 = builder.append(Operation::DerivePoint, &[bitcoin_sk_1]);
+        let funding_pubkey_2 = builder.append(Operation::DerivePoint, &[bitcoin_sk_2]);
+
+        // Load the funding amount and feerate rather than picking them, since a
+        // full-range random amount exceeds Bitcoin's maximum supply and fails
+        // coin selection, aborting the program before the announcement is sent.
+        let funding_satoshis = builder.append(
+            Operation::LoadAmount(rng.random_range(0..=Self::MAX_FUNDING_SATOSHIS)),
+            &[],
+        );
+        let feerate_per_kw = builder.append(
+            Operation::LoadFeeratePerKw(rng.random_range(0..=Self::MAX_FEERATE_PER_KW)),
+            &[],
+        );
+
+        // Create the 2-of-2 P2WSH funding transaction and confirm it.
+        let funding_transaction = builder.append(
+            Operation::CreateFundingTransaction,
+            &[
+                funding_pubkey_1,
+                funding_pubkey_2,
+                funding_satoshis,
+                feerate_per_kw,
+            ],
+        );
+        builder.append(Operation::BroadcastTransaction, &[funding_transaction]);
+        builder.append(Operation::MineBlocks(rng.random_range(1..=16)), &[]);
+
+        // Derive the short_channel_id from the confirmed funding output.
+        let short_channel_id =
+            builder.append(Operation::LookupShortChannelId, &[funding_transaction]);
+
+        // Build and send channel_announcement.
         let msg = builder.append(
             Operation::BuildChannelAnnouncement,
             &[
                 features,
                 chain_hash,
-                scid,
+                short_channel_id,
                 node_sk_1,
                 node_sk_2,
                 bitcoin_sk_1,

--- a/smite-ir/src/generators/channel_announcement.rs
+++ b/smite-ir/src/generators/channel_announcement.rs
@@ -1,20 +1,38 @@
 //! Generator for `channel_announcement` gossip message.
 
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 use super::Generator;
 use crate::builder::ProgramBuilder;
 use crate::{Operation, VariableType};
 
-/// Generates an unsolicited `channel_announcement` send.
+/// Generates an unsolicited `channel_announcement` send backed by a real
+/// funding output.
+///
+/// Emits instructions to:
+/// 1. Create, broadcast, and confirm a 2-of-2 P2WSH funding transaction
+/// 2. Look up the `short_channel_id` of the confirmed funding output
+/// 3. Build and send `channel_announcement`
+///
+/// The announced bitcoin keys are the ones committed to by the funding
+/// output's witness script, so the message can pass the on-chain UTXO
+/// validation performed by CLN and LND.
 #[derive(Clone, Copy)]
 pub struct ChannelAnnouncementGenerator;
+
+impl ChannelAnnouncementGenerator {
+    /// BOLT 2 caps `funding_satoshis` at 2^24-1 for non-wumbo channels, and we
+    /// only have so much wallet balance to spend.
+    pub const MAX_FUNDING_SATOSHIS: u64 = 16_777_215;
+
+    /// Bounded so that fees don't exhaust the wallet.
+    pub const MAX_FEERATE_PER_KW: u32 = 10_000;
+}
 
 impl Generator for ChannelAnnouncementGenerator {
     fn generate(&self, builder: &mut ProgramBuilder, rng: &mut impl Rng) {
         let features = builder.pick_variable(VariableType::Features, rng);
         let chain_hash = builder.pick_variable(VariableType::ChainHash, rng);
-        let scid = builder.pick_variable(VariableType::ShortChannelId, rng);
 
         // Use fresh private keys since channel_announcement validation
         // generally requires distinct keys.
@@ -23,12 +41,49 @@ impl Generator for ChannelAnnouncementGenerator {
         let bitcoin_sk_1 = builder.generate_fresh(VariableType::PrivateKey, rng);
         let bitcoin_sk_2 = builder.generate_fresh(VariableType::PrivateKey, rng);
 
+        // The funding output must pay to the same bitcoin keys the message
+        // announces, so derive the funding pubkeys instead of picking them.
+        let funding_pubkey_1 = builder.append(Operation::DerivePoint, &[bitcoin_sk_1]);
+        let funding_pubkey_2 = builder.append(Operation::DerivePoint, &[bitcoin_sk_2]);
+
+        // Load the funding amount and feerate rather than picking them, since a
+        // full-range random amount exceeds Bitcoin's maximum supply and fails
+        // coin selection, aborting the program before the announcement is sent.
+        let funding_satoshis = builder.append(
+            Operation::LoadAmount(rng.random_range(0..=Self::MAX_FUNDING_SATOSHIS)),
+            &[],
+        );
+        let feerate_per_kw = builder.append(
+            Operation::LoadFeeratePerKw(rng.random_range(0..=Self::MAX_FEERATE_PER_KW)),
+            &[],
+        );
+
+        // Create the 2-of-2 P2WSH funding transaction and confirm it.
+        let funding_transaction = builder.append(
+            Operation::CreateFundingTransaction,
+            &[
+                funding_pubkey_1,
+                funding_pubkey_2,
+                funding_satoshis,
+                feerate_per_kw,
+            ],
+        );
+        builder.append(Operation::BroadcastTransaction, &[funding_transaction]);
+        builder.append(Operation::MineBlocks(rng.random_range(1..=16)), &[]);
+
+        // Derive the short_channel_id from the confirmed funding output. If a
+        // mutator drops the MineBlocks above, the executor yields a sentinel
+        // scid and the announcement simply fails on-chain validation.
+        let short_channel_id =
+            builder.append(Operation::LookupShortChannelId, &[funding_transaction]);
+
+        // Build and send channel_announcement.
         let msg = builder.append(
             Operation::BuildChannelAnnouncement,
             &[
                 features,
                 chain_hash,
-                scid,
+                short_channel_id,
                 node_sk_1,
                 node_sk_2,
                 bitcoin_sk_1,

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -1406,6 +1406,94 @@ fn generated_channel_announcement_program_structure() {
         build_count, 1,
         "expected exactly one BuildChannelAnnouncement"
     );
+
+    // The funding transaction must be created, broadcast, and confirmed before
+    // its short_channel_id is looked up.
+    let create = find_operation!(program, Operation::CreateFundingTransaction);
+    let broadcast = find_operation!(program, Operation::BroadcastTransaction);
+    let mine = find_operation!(program, Operation::MineBlocks(_));
+    let lookup = find_operation!(program, Operation::LookupShortChannelId);
+    assert!(
+        create < broadcast && broadcast < mine && mine < lookup,
+        "expected Create < Broadcast < Mine < Lookup, got {create} {broadcast} {mine} {lookup}",
+    );
+}
+
+// The bitcoin keys the message announces must be the ones committed to by
+// the funding output's witness script, and the announced scid must come from
+// that same funding transaction. Otherwise the announcement cannot pass
+// on-chain validation.
+#[test]
+fn generated_channel_announcement_commits_to_its_funding_output() {
+    let program = generate_channel_announcement_program(0);
+
+    let create_idx = find_operation!(program, Operation::CreateFundingTransaction);
+    let lookup_idx = find_operation!(program, Operation::LookupShortChannelId);
+    let build_idx = find_operation!(program, Operation::BuildChannelAnnouncement);
+
+    let create = &program.instructions[create_idx];
+    let lookup = &program.instructions[lookup_idx];
+    let build = &program.instructions[build_idx];
+
+    // The scid is looked up from the funding transaction just created, and
+    // that scid is what the announcement carries. LookupShortChannelId input 0
+    // is the funding transaction; BuildChannelAnnouncement input 2 is the
+    // announced short_channel_id.
+    assert_eq!(
+        lookup.inputs[0], create_idx,
+        "LookupShortChannelId should read the funding transaction just created",
+    );
+    assert_eq!(
+        build.inputs[2], lookup_idx,
+        "the announced short_channel_id should be the one looked up from the funding transaction",
+    );
+
+    // Each announced bitcoin key is the private key behind the corresponding
+    // funding pubkey. CreateFundingTransaction inputs 0 and 1 are the funding
+    // pubkeys; BuildChannelAnnouncement inputs 5 and 6 are the announced
+    // bitcoin_key_1 and bitcoin_key_2.
+    for (funding_pos, announced_pos) in [(0, 5), (1, 6)] {
+        let derive = &program.instructions[create.inputs[funding_pos]];
+        assert!(
+            matches!(derive.operation, Operation::DerivePoint),
+            "funding pubkey {funding_pos} should be a DerivePoint",
+        );
+        assert_eq!(
+            derive.inputs[0],
+            build.inputs[announced_pos],
+            "bitcoin_key_{} must be the private key behind funding pubkey {funding_pos}",
+            funding_pos + 1,
+        );
+    }
+}
+
+// Coin selection fails outright for amounts above Bitcoin's maximum supply, so
+// the generator must emit plausible funding values rather than full-range
+// randoms. Without this the program exits before sending the announcement.
+#[test]
+fn generated_channel_announcement_uses_plausible_funding_values() {
+    for seed in 0..100 {
+        let program = generate_channel_announcement_program(seed);
+        let create_idx = find_operation!(program, Operation::CreateFundingTransaction);
+        let create = &program.instructions[create_idx];
+
+        // CreateFundingTransaction input 2 is the funding amount and input 3
+        // is the feerate.
+        match &program.instructions[create.inputs[2]].operation {
+            Operation::LoadAmount(sats) => assert!(
+                *sats <= ChannelAnnouncementGenerator::MAX_FUNDING_SATOSHIS,
+                "seed {seed}: implausible funding amount {sats}",
+            ),
+            op => panic!("seed {seed}: expected LoadAmount, got {op}"),
+        }
+        match &program.instructions[create.inputs[3]].operation {
+            Operation::LoadFeeratePerKw(feerate) => assert!(
+                *feerate <= ChannelAnnouncementGenerator::MAX_FEERATE_PER_KW,
+                "seed {seed}: implausible feerate {feerate}",
+            ),
+            op => panic!("seed {seed}: expected LoadFeeratePerKw, got {op}"),
+        }
+    }
 }
 
 fn generate_node_announcement_program(seed: u64) -> Program {
@@ -2301,8 +2389,8 @@ fn instr_reorder_returns_false_on_empty() {
 
 #[test]
 fn instr_reorder_returns_false_on_single_or_no_act() {
-    // ChannelAnnouncementGenerator produces a single Act instruction: SendMessage.
-    let mut program = generate_channel_announcement_program(0);
+    // NodeAnnouncementGenerator produces a single Act instruction: SendMessage.
+    let mut program = generate_node_announcement_program(0);
     let mutator = InstructionReorderMutator;
     let mut rng = SmallRng::seed_from_u64(0);
 

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -34,6 +34,22 @@ fn assert_well_formed(program: &Program) {
     }
 }
 
+/// Returns the index of the first instruction in `$program` whose operation
+/// matches `$pattern`.
+///
+/// # Panics
+///
+/// Panics if `$program` contains no matching instruction.
+macro_rules! find_operation {
+    ($program:expr, $pattern:pat) => {
+        $program
+            .instructions
+            .iter()
+            .position(|i| matches!(i.operation, $pattern))
+            .unwrap_or_else(|| panic!("expected a {}", stringify!($pattern)))
+    };
+}
+
 #[test]
 #[allow(clippy::too_many_lines)]
 fn display_open_channel_program() {
@@ -1321,18 +1337,12 @@ fn generated_funding_flow_program_structure() {
     );
 
     // Key operations must appear in protocol order.
-    let position = |pred: fn(&Operation) -> bool| {
-        ops.iter()
-            .position(|op| pred(op))
-            .expect("operation present")
-    };
-
-    let recv_accept_channel = position(|op| matches!(op, Operation::RecvAcceptChannel));
-    let send_funding_created = position(|op| matches!(op, Operation::SendFundingCreated));
-    let recv_funding_signed = position(|op| matches!(op, Operation::RecvFundingSigned));
-    let broadcast_transaction = position(|op| matches!(op, Operation::BroadcastTransaction));
-    let send_channel_ready = position(|op| matches!(op, Operation::SendChannelReady { .. }));
-    let recv_channel_ready = position(|op| matches!(op, Operation::RecvChannelReady));
+    let recv_accept_channel = find_operation!(program, Operation::RecvAcceptChannel);
+    let send_funding_created = find_operation!(program, Operation::SendFundingCreated);
+    let recv_funding_signed = find_operation!(program, Operation::RecvFundingSigned);
+    let broadcast_transaction = find_operation!(program, Operation::BroadcastTransaction);
+    let send_channel_ready = find_operation!(program, Operation::SendChannelReady { .. });
+    let recv_channel_ready = find_operation!(program, Operation::RecvChannelReady);
 
     assert!(
         recv_accept_channel < send_funding_created,

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -1384,6 +1384,102 @@ fn generated_channel_announcement_program_structure() {
         build_count, 1,
         "expected exactly one BuildChannelAnnouncement"
     );
+
+    // The funding transaction must be created, broadcast, and confirmed before
+    // its short_channel_id is looked up.
+    let position = |target: &Operation| {
+        ops.iter()
+            .position(|op| std::mem::discriminant(*op) == std::mem::discriminant(target))
+            .unwrap_or_else(|| panic!("expected a {target}"))
+    };
+    let create = position(&Operation::CreateFundingTransaction);
+    let broadcast = position(&Operation::BroadcastTransaction);
+    let mine = position(&Operation::MineBlocks(0));
+    let lookup = position(&Operation::LookupShortChannelId);
+    assert!(
+        create < broadcast && broadcast < mine && mine < lookup,
+        "expected Create < Broadcast < Mine < Lookup, got {create} {broadcast} {mine} {lookup}",
+    );
+}
+
+// The bitcoin keys the message announces must be the ones committed to by
+// the funding output's witness script, and the announced scid must come from
+// that same funding transaction. Otherwise the announcement cannot pass
+// on-chain validation.
+#[test]
+fn generated_channel_announcement_commits_to_its_funding_output() {
+    for seed in 0..100 {
+        let program = generate_channel_announcement_program(seed);
+        let find = |target: &Operation| {
+            program
+                .instructions
+                .iter()
+                .position(|i| {
+                    std::mem::discriminant(&i.operation) == std::mem::discriminant(target)
+                })
+                .unwrap_or_else(|| panic!("expected a {target}"))
+        };
+
+        let create_idx = find(&Operation::CreateFundingTransaction);
+        let lookup_idx = find(&Operation::LookupShortChannelId);
+        let build_idx = find(&Operation::BuildChannelAnnouncement);
+
+        let create = &program.instructions[create_idx];
+        let lookup = &program.instructions[lookup_idx];
+        let build = &program.instructions[build_idx];
+
+        // The scid is looked up from the funding transaction just created, and
+        // that scid is what the announcement carries.
+        assert_eq!(lookup.inputs[0], create_idx, "seed {seed}: scid lookup");
+        assert_eq!(build.inputs[2], lookup_idx, "seed {seed}: announced scid");
+
+        // Each announced bitcoin key is the private key behind the
+        // corresponding funding pubkey.
+        for (funding_pos, announced_pos) in [(0, 5), (1, 6)] {
+            let derive = &program.instructions[create.inputs[funding_pos]];
+            assert!(
+                matches!(derive.operation, Operation::DerivePoint),
+                "seed {seed}: funding pubkey {funding_pos} should be a DerivePoint",
+            );
+            assert_eq!(
+                derive.inputs[0],
+                build.inputs[announced_pos],
+                "seed {seed}: bitcoin_key_{} must match the funding output",
+                funding_pos + 1,
+            );
+        }
+    }
+}
+
+// Coin selection fails outright for amounts above Bitcoin's maximum supply, so
+// the generator must emit plausible funding values rather than full-range
+// randoms. Without this the program aborts before sending the announcement.
+#[test]
+fn generated_channel_announcement_uses_plausible_funding_values() {
+    for seed in 0..100 {
+        let program = generate_channel_announcement_program(seed);
+        let create_idx = program
+            .instructions
+            .iter()
+            .position(|i| matches!(i.operation, Operation::CreateFundingTransaction))
+            .expect("expected a CreateFundingTransaction");
+        let create = &program.instructions[create_idx];
+
+        match program.instructions[create.inputs[2]].operation {
+            Operation::LoadAmount(sats) => assert!(
+                (0..=ChannelAnnouncementGenerator::MAX_FUNDING_SATOSHIS).contains(&sats),
+                "seed {seed}: implausible funding amount {sats}",
+            ),
+            ref op => panic!("seed {seed}: expected LoadAmount, got {op}"),
+        }
+        match program.instructions[create.inputs[3]].operation {
+            Operation::LoadFeeratePerKw(feerate) => assert!(
+                (0..=ChannelAnnouncementGenerator::MAX_FEERATE_PER_KW).contains(&feerate),
+                "seed {seed}: implausible feerate {feerate}",
+            ),
+            ref op => panic!("seed {seed}: expected LoadFeeratePerKw, got {op}"),
+        }
+    }
 }
 
 fn generate_node_announcement_program(seed: u64) -> Program {
@@ -2279,8 +2375,8 @@ fn instr_reorder_returns_false_on_empty() {
 
 #[test]
 fn instr_reorder_returns_false_on_single_or_no_act() {
-    // ChannelAnnouncementGenerator produces a single Act instruction: SendMessage.
-    let mut program = generate_channel_announcement_program(0);
+    // NodeAnnouncementGenerator produces a single Act instruction: SendMessage.
+    let mut program = generate_node_announcement_program(0);
     let mutator = InstructionReorderMutator;
     let mut rng = SmallRng::seed_from_u64(0);
 


### PR DESCRIPTION
`ChannelAnnouncementGenerator` now creates, broadcasts, and confirms a 2-of-2 P2WSH funding transaction, and announces the `short_channel_id` it lands at along with the bitcoin keys its witness script commits to.  The messages can then pass the on-chain UTXO validation performed by CLN and LND.

#155 resolved the `short_channel_id` half of this, but nothing ever emitted the operation, and the generator picked its bitcoin keys with `generate_fresh`, unrelated to any funding output.  Deriving the funding pubkeys from the announced private keys closes the gap.  No new operations are needed, since `DerivePoint`, `CreateFundingTransaction`, `BroadcastTransaction`, `MineBlocks`, and `LookupShortChannelId` already compose.

`funding_satoshis` and `feerate_per_kw` are emitted directly instead of picked, since `generate_fresh(Amount)` draws from the full u64 range and exceeds `MAX_MONEY` essentially always, which fails coin selection and aborts the program before the announcement is sent.  Only the maximums are bounded: the funding amount is capped at BOLT 2's non-wumbo limit and the feerate is capped so fees don't exhaust the wallet.  Both may still go to zero, since `sign_and_broadcast_tx` already falls back to mining dust outputs and below-min-relay-feerate transactions directly.  `OperationParamMutator` can widen both afterwards.

`FundingFlowGenerator` picks those same two values with `pick_variable` and has the same full-range exposure, which seems worth a follow-up.

Tested with unit tests covering the ordering of the funding sequence, that each announced bitcoin key is the one behind the corresponding funding pubkey, and that the generated amounts stay in range.  Not yet fuzzed against the targets; I'll follow up with coverage once I've run a campaign.

Ref: #71
