### PR TITLE
smite-scenarios: log messages in name(type) format

### DIFF
--- a/scripts/check-bolt-msg-type-order.sh
+++ b/scripts/check-bolt-msg-type-order.sh
@@ -75,8 +75,8 @@ order_impl_message_encode() {
 order_impl_message_decode() {
     impl_message_block | \
         awk '/^    pub fn decode/,/^    }/ { print }' | \
-        grep "MessageType::" | \
-        sed -e 's/MessageType:://' -e 's/ =>.*//' | \
+        grep -oE "MessageType::[A-Z0-9_]+ =>" | \
+        sed -e 's/MessageType:://' -e 's/ =>//' | \
         grep -v "Unknown" | \
         to_canonical
 }
@@ -96,7 +96,7 @@ order_tests() {
 order_tests_message_type_values() {
     tests_block | \
         awk '/^    fn message_type_values\(\) {/,/^    }/ { print }' | \
-        grep -oE "MessageType::[A-Za-z0-9_]+" | \
+        grep -oE "MessageType::[A-Z0-9_]+" | \
         sed 's/MessageType:://' | \
         to_canonical
 }

--- a/scripts/check-bolt-msg-type-order.sh
+++ b/scripts/check-bolt-msg-type-order.sh
@@ -9,19 +9,19 @@ set -o pipefail
 
 FILE=smite/src/bolt.rs
 
-order_pub_mod_msg_type() {
+order_message_type() {
     # awk '/start/,/end/ { print }' <file>
     #   Print everything between the lines matching start and end
     # grep x3
-    #   Print the last number of every line matching "pub const" (BOLT message type constant)
-    awk '/^pub mod msg_type {/,/^}/ { print }' $FILE | \
+    #   Print the BOLT message type number inside MessageType() of every line
+    awk '/^impl MessageType {/,/^}/ { print }' $FILE | \
         grep "pub const" | \
-        grep -oE '= [0-9]+;$' | \
+        grep -oE '= MessageType\([0-9]+\);$' | \
         grep -oE '[0-9]+'
 }
 
-echo "Checking pub mod msg_type { ... }"
-diff -u <(order_pub_mod_msg_type) <(order_pub_mod_msg_type | sort -n)
+echo "Checking order impl MessageType { ... }"
+diff -u <(order_message_type) <(order_message_type | sort -n)
 echo "OK"
 
 # We now know the keys are in the correct order. We can now use a
@@ -32,9 +32,10 @@ to_canonical() {
 }
 
 order_canonical_keys() {
-    # print all keys in pub mod msg_type { ... }
-    awk '/^pub mod msg_type {/,/^}/ { print }' $FILE | \
+    # print all keys in impl MessageType { ... }
+    awk '/^impl MessageType {/,/^}/ { print }' $FILE | \
         grep "pub const" | \
+        grep -v "pub const fn" | \
         awk '{ print $3 }' | \
         to_canonical
 }
@@ -74,8 +75,8 @@ order_impl_message_encode() {
 order_impl_message_decode() {
     impl_message_block | \
         awk '/^    pub fn decode/,/^    }/ { print }' | \
-        grep "msg_type::" | \
-        sed -e 's/msg_type:://' -e 's/ =>.*//' | \
+        grep "MessageType::" | \
+        sed -e 's/MessageType:://' -e 's/ =>.*//' | \
         grep -v "Unknown" | \
         to_canonical
 }
@@ -95,8 +96,8 @@ order_tests() {
 order_tests_message_type_values() {
     tests_block | \
         awk '/^    fn message_type_values\(\) {/,/^    }/ { print }' | \
-        grep -oE "msg_type::[A-Za-z0-9_]+" | \
-        sed 's/msg_type:://' | \
+        grep -oE "MessageType::[A-Za-z0-9_]+" | \
+        sed 's/MessageType:://' | \
         to_canonical
 }
 

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -9,8 +9,8 @@ use bitcoin::{OutPoint, ScriptBuf, Txid};
 use smite::bitcoin::{BitcoinCli, TxBlockPosition, Utxo};
 use smite::bolt::{
     AcceptChannel, AnnouncementSignatures, ChannelAnnouncement, ChannelId, ChannelReady,
-    ChannelReadyTlvs, ChannelUpdate, FundingCreated, FundingSigned, Message, NodeAnnouncement,
-    OpenChannel, OpenChannelTlvs, Pong, ShortChannelId, Shutdown, msg_type,
+    ChannelReadyTlvs, ChannelUpdate, FundingCreated, FundingSigned, Message, MessageType,
+    NodeAnnouncement, OpenChannel, OpenChannelTlvs, Pong, ShortChannelId, Shutdown,
 };
 use smite::channel_tx::{
     ChannelConfig, ChannelPartyConfig, ChannelState, FundingTransaction, HolderIdentity, Side,
@@ -203,8 +203,11 @@ pub enum ExecuteError {
     Decode(#[from] smite::bolt::BoltError),
 
     /// Received a different message type than expected.
-    #[error("unexpected message: expected type {expected}, got {got}")]
-    UnexpectedMessage { expected: u16, got: u16 },
+    #[error("unexpected message: expected {expected}, got {got}")]
+    UnexpectedMessage {
+        expected: MessageType,
+        got: MessageType,
+    },
 
     /// The target sent a BOLT `error`.
     #[error("peer error on {:?}: {}", .0.channel_id, .0.message().unwrap_or("<non-utf8>"))]
@@ -1245,7 +1248,7 @@ fn recv_accept_channel(conn: &mut impl Connection) -> Result<AcceptChannel, Exec
     match recv_non_ping(conn, RECV_IDLE_TIMEOUT)? {
         Message::AcceptChannel(ac) => Ok(ac),
         other => Err(ExecuteError::UnexpectedMessage {
-            expected: msg_type::ACCEPT_CHANNEL,
+            expected: MessageType::ACCEPT_CHANNEL,
             got: other.msg_type(),
         }),
     }
@@ -1256,7 +1259,7 @@ fn recv_funding_signed(conn: &mut impl Connection) -> Result<FundingSigned, Exec
     match recv_non_ping(conn, RECV_IDLE_TIMEOUT)? {
         Message::FundingSigned(fs) => Ok(fs),
         other => Err(ExecuteError::UnexpectedMessage {
-            expected: msg_type::FUNDING_SIGNED,
+            expected: MessageType::FUNDING_SIGNED,
             got: other.msg_type(),
         }),
     }
@@ -1280,7 +1283,7 @@ fn recv_channel_ready(
         Message::ChannelReady(cr) => cr,
         other => {
             return Err(ExecuteError::UnexpectedMessage {
-                expected: msg_type::CHANNEL_READY,
+                expected: MessageType::CHANNEL_READY,
                 got: other.msg_type(),
             });
         }
@@ -2448,8 +2451,8 @@ mod tests {
         assert!(matches!(
             err,
             ExecuteError::UnexpectedMessage {
-                expected: msg_type::ACCEPT_CHANNEL,
-                got: msg_type::INIT,
+                expected: MessageType::ACCEPT_CHANNEL,
+                got: MessageType::INIT,
             }
         ));
     }

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -406,10 +406,15 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
                 // -- Act operations --
                 Operation::SendMessage => {
                     let bytes = resolve_message(&variables, instr.inputs[0]);
-                    let msg_type = bytes.get(..2).map(|b| u16::from_be_bytes([b[0], b[1]]));
+                    let ty = u16::from_be_bytes(
+                        *bytes
+                            .first_chunk::<2>()
+                            .expect("encoded message has a 2-byte type prefix"),
+                    );
                     log::debug!(
-                        "[{:?}] SendMessage: type {msg_type:?}, {} bytes",
+                        "[{:?}] SendMessage: {}, {} bytes",
                         start.elapsed(),
+                        MessageType::from_u16(ty),
                         bytes.len(),
                     );
                     self.conn.send_message(bytes)?;
@@ -1219,8 +1224,8 @@ fn recv_non_ping(conn: &mut impl Connection, timeout: Duration) -> Result<Messag
                 let pong = Message::Pong(Pong::respond_to(&ping)).encode();
                 conn.send_message(&pong)?;
             }
-            Message::Unknown { msg_type, .. } => {
-                log::debug!("skipping unknown message type {msg_type}");
+            Message::Unknown { .. } => {
+                log::debug!("skipping message {msg}");
             }
             // TODO: Gossip messages are not currently consumed by any scenario,
             // so skip them for now. Revisit this once we want to extract their
@@ -1230,7 +1235,7 @@ fn recv_non_ping(conn: &mut impl Connection, timeout: Duration) -> Result<Messag
             | Message::ChannelUpdate(_)
             | Message::AnnouncementSignatures(_)
             | Message::GossipTimestampFilter(_) => {
-                log::debug!("skipping gossip message type {}", msg.msg_type());
+                log::debug!("skipping gossip message {msg}");
             }
             // Surface the received error message.
             Message::Error(e) => return Err(ExecuteError::PeerError(e)),
@@ -1802,17 +1807,14 @@ mod tests {
     fn decode_sent_channel_announcement(bytes: &[u8]) -> ChannelAnnouncement {
         match Message::decode(bytes).expect("valid message") {
             Message::ChannelAnnouncement(ca) => ca,
-            other => panic!(
-                "expected ChannelAnnouncement, got type {}",
-                other.msg_type()
-            ),
+            other => panic!("expected channel_announcement(256), got {other}"),
         }
     }
 
     fn decode_open_channel(bytes: &[u8]) -> OpenChannel {
         match Message::decode(bytes).expect("valid message") {
             Message::OpenChannel(oc) => oc,
-            other => panic!("expected OpenChannel, got type {}", other.msg_type()),
+            other => panic!("expected open_channel(32), got {other}"),
         }
     }
 
@@ -1945,10 +1947,7 @@ mod tests {
         assert_eq!(executor.conn.sent.len(), 1);
         let ca = match Message::decode(&executor.conn.sent[0]).expect("valid message") {
             Message::ChannelAnnouncement(ca) => ca,
-            other => panic!(
-                "expected ChannelAnnouncement, got type {}",
-                other.msg_type()
-            ),
+            other => panic!("expected channel_announcement(256), got {other}"),
         };
 
         let secp = Secp256k1::new();
@@ -2016,7 +2015,7 @@ mod tests {
         assert_eq!(executor.conn.sent.len(), 1);
         let na = match Message::decode(&executor.conn.sent[0]).expect("valid message") {
             Message::NodeAnnouncement(na) => na,
-            other => panic!("expected NodeAnnouncement, got type {}", other.msg_type()),
+            other => panic!("expected node_announcement(257), got {other}"),
         };
 
         let secp = Secp256k1::new();
@@ -2108,7 +2107,7 @@ mod tests {
         assert_eq!(executor.conn.sent.len(), 1);
         let cu = match Message::decode(&executor.conn.sent[0]).expect("valid message") {
             Message::ChannelUpdate(cu) => cu,
-            other => panic!("expected ChannelUpdate, got type {}", other.msg_type()),
+            other => panic!("expected channel_update(258), got {other}"),
         };
 
         assert_eq!(cu.chain_hash, sample_context().chain_hash);
@@ -2219,10 +2218,7 @@ mod tests {
         assert_eq!(executor.conn.sent.len(), 1);
         let ann_sigs = match Message::decode(&executor.conn.sent[0]).expect("valid message") {
             Message::AnnouncementSignatures(s) => s,
-            other => panic!(
-                "expected AnnouncementSignatures, got type {}",
-                other.msg_type()
-            ),
+            other => panic!("expected announcement_signatures(259), got {other}"),
         };
 
         assert_eq!(ann_sigs.channel_id, ChannelId::new(channel_id_bytes));
@@ -2521,13 +2517,13 @@ mod tests {
         // Verify the first message was `open_channel`.
         let oc = Message::decode(&executor.conn.sent[0]).unwrap();
         let Message::OpenChannel(_) = oc else {
-            panic!("expected OpenChannel, got {:?}", oc.msg_type());
+            panic!("expected open_channel(32), got {oc}");
         };
 
         // Verify the second message was the pong.
         let pong = Message::decode(&executor.conn.sent[1]).unwrap();
         let Message::Pong(pong) = pong else {
-            panic!("expected Pong, got {:?}", pong.msg_type());
+            panic!("expected pong(19), got {pong}");
         };
         assert_eq!(pong.ignored.len(), 4);
     }
@@ -3399,7 +3395,7 @@ mod tests {
         assert_eq!(executor.conn.sent.len(), 1);
         let fc = match Message::decode(&executor.conn.sent[0]).expect("valid message") {
             Message::FundingCreated(fc) => fc,
-            other => panic!("expected FundingCreated, got type {}", other.msg_type()),
+            other => panic!("expected funding_created(34), got {other}"),
         };
 
         assert_eq!(fc.temporary_channel_id, ChannelId::new([0xbb; 32]));
@@ -3515,7 +3511,7 @@ mod tests {
 
         let fc = match Message::decode(&executor.conn.sent[0]).expect("valid message") {
             Message::FundingCreated(fc) => fc,
-            other => panic!("expected FundingCreated, got type {}", other.msg_type()),
+            other => panic!("expected funding_created(34), got {other}"),
         };
         assert_eq!(fc.temporary_channel_id, ChannelId::new([0xbb; 32]));
         assert_eq!(
@@ -3557,7 +3553,7 @@ mod tests {
 
         let fc = match Message::decode(&executor.conn.sent[0]).expect("valid message") {
             Message::FundingCreated(fc) => fc,
-            other => panic!("expected FundingCreated, got type {}", other.msg_type()),
+            other => panic!("expected funding_created(34), got {other}"),
         };
         assert_eq!(fc.temporary_channel_id, ChannelId::new([0xbb; 32]));
         assert_eq!(
@@ -3710,7 +3706,7 @@ mod tests {
         // not carry the short_channel_id TLV.
         let cr1 = match Message::decode(&executor.conn.sent[1]).expect("valid message") {
             Message::ChannelReady(cr) => cr,
-            other => panic!("expected ChannelReady, got type {}", other.msg_type()),
+            other => panic!("expected channel_ready(36), got {other}"),
         };
         let expected_pcp1 = PublicKey::from_str(
             "023da092f6980e58d2c037173180e9a465476026ee50f96695963e8efe436f54eb",
@@ -3724,7 +3720,7 @@ mod tests {
         // carry the alias SCID we loaded in its short_channel_id TLV.
         let cr2 = match Message::decode(&executor.conn.sent[2]).expect("valid message") {
             Message::ChannelReady(cr) => cr,
-            other => panic!("expected ChannelReady, got type {}", other.msg_type()),
+            other => panic!("expected channel_ready(36), got {other}"),
         };
         let expected_pcp2 = PublicKey::from_str(
             "030e9f7b623d2ccc7c9bd44d66d5ce21ce504c0acf6385a132cec6d3c39fa711c1",
@@ -3776,7 +3772,7 @@ mod tests {
         assert_eq!(executor.conn.sent.len(), 1);
         let sd = match Message::decode(&executor.conn.sent[0]).expect("valid message") {
             Message::Shutdown(sd) => sd,
-            other => panic!("expected Shutdown, got type {}", other.msg_type()),
+            other => panic!("expected shutdown(38), got {other}"),
         };
         assert_eq!(sd.channel_id, channel_id);
         assert_eq!(sd.scriptpubkey, script.encode());
@@ -3816,7 +3812,7 @@ mod tests {
         assert_eq!(executor.conn.sent.len(), 1);
         let sd = match Message::decode(&executor.conn.sent[0]).expect("valid message") {
             Message::Shutdown(sd) => sd,
-            other => panic!("expected Shutdown, got type {}", other.msg_type()),
+            other => panic!("expected shutdown(38), got {other}"),
         };
         assert_eq!(sd.channel_id, channel_id);
         assert!(sd.scriptpubkey.is_empty());

--- a/smite-scenarios/src/scenarios/init.rs
+++ b/smite-scenarios/src/scenarios/init.rs
@@ -59,7 +59,7 @@ impl<T: Target> Scenario for InitScenario<T> {
         );
 
         // Send an init-typed message with fuzz payload.
-        let msg = bolt::message_with_type(bolt::msg_type::INIT, input);
+        let msg = bolt::message_with_type(bolt::MessageType::INIT.as_u16(), input);
         let truncated = &msg[..msg.len().min(MAX_MESSAGE_SIZE)];
         self.conn
             .send_message(truncated)

--- a/smite-scenarios/src/scenarios/init.rs
+++ b/smite-scenarios/src/scenarios/init.rs
@@ -59,7 +59,7 @@ impl<T: Target> Scenario for InitScenario<T> {
         );
 
         // Send an init-typed message with fuzz payload.
-        let msg = bolt::message_with_type(bolt::MessageType::INIT.as_u16(), input);
+        let msg = bolt::message_with_type(bolt::MessageType::INIT, input);
         let truncated = &msg[..msg.len().min(MAX_MESSAGE_SIZE)];
         self.conn
             .send_message(truncated)

--- a/smite-scenarios/src/scenarios/ir.rs
+++ b/smite-scenarios/src/scenarios/ir.rs
@@ -71,14 +71,11 @@ impl<T: Target, S: SnapshotSetup<T>> Scenario for IrScenario<T, S> {
                 // crash.
                 log::debug!("[{:?}] execute connection error: {e}", start.elapsed());
             }
-            Err(ExecuteError::UnexpectedMessage { expected, got }) => {
+            Err(e @ ExecuteError::UnexpectedMessage { .. }) => {
                 // Target replied with an unexpected message type (often
                 // Error/Warning when rejecting our input). Usually normal
                 // protocol behavior.
-                log::debug!(
-                    "[{:?}] unexpected message: expected {expected}, got {got}",
-                    start.elapsed(),
-                );
+                log::debug!("[{:?}] {e}", start.elapsed());
             }
             Err(ExecuteError::PeerError(e)) => {
                 // Normal protocol behavior: the target rejected our input.

--- a/smite-scenarios/src/scenarios/noise.rs
+++ b/smite-scenarios/src/scenarios/noise.rs
@@ -87,7 +87,7 @@ impl<T: Target> NoiseScenario<T> {
         let init_bytes = recv_message(&mut self.stream, cipher);
         let init = match Message::decode(&init_bytes).expect("valid init message") {
             Message::Init(init) => init,
-            other => panic!("expected init, got {other:?}"),
+            other => panic!("expected init(16), got {other}"),
         };
         let echo_init = Init::echo(&init);
         let encoded = Message::Init(echo_init).encode();

--- a/smite/src/bolt.rs
+++ b/smite/src/bolt.rs
@@ -135,74 +135,138 @@ pub enum BoltError {
     },
 }
 
-/// BOLT message type constants.
-pub mod msg_type {
+/// A BOLT message type number that displays as `name(type)`, e.g.
+/// `open_channel(32)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MessageType(u16);
+
+impl MessageType {
     /// Warning message (BOLT 1).
-    pub const WARNING: u16 = 1;
+    pub const WARNING: MessageType = MessageType(1);
     /// Init message (BOLT 1).
-    pub const INIT: u16 = 16;
+    pub const INIT: MessageType = MessageType(16);
     /// Error message (BOLT 1).
-    pub const ERROR: u16 = 17;
+    pub const ERROR: MessageType = MessageType(17);
     /// Ping message (BOLT 1).
-    pub const PING: u16 = 18;
+    pub const PING: MessageType = MessageType(18);
     /// Pong message (BOLT 1).
-    pub const PONG: u16 = 19;
+    pub const PONG: MessageType = MessageType(19);
     /// `open_channel` message (BOLT 2).
-    pub const OPEN_CHANNEL: u16 = 32;
+    pub const OPEN_CHANNEL: MessageType = MessageType(32);
     /// `accept_channel` message (BOLT 2).
-    pub const ACCEPT_CHANNEL: u16 = 33;
+    pub const ACCEPT_CHANNEL: MessageType = MessageType(33);
     /// `funding_created` message (BOLT 2).
-    pub const FUNDING_CREATED: u16 = 34;
+    pub const FUNDING_CREATED: MessageType = MessageType(34);
     /// `funding_signed` message (BOLT 2).
-    pub const FUNDING_SIGNED: u16 = 35;
+    pub const FUNDING_SIGNED: MessageType = MessageType(35);
     /// `channel_ready` message (BOLT 2).
-    pub const CHANNEL_READY: u16 = 36;
+    pub const CHANNEL_READY: MessageType = MessageType(36);
     /// Shutdown message (BOLT 2).
-    pub const SHUTDOWN: u16 = 38;
+    pub const SHUTDOWN: MessageType = MessageType(38);
     /// `closing_complete` message (BOLT 2).
-    pub const CLOSING_COMPLETE: u16 = 40;
+    pub const CLOSING_COMPLETE: MessageType = MessageType(40);
     /// `closing_sig` message (BOLT 2).
-    pub const CLOSING_SIG: u16 = 41;
+    pub const CLOSING_SIG: MessageType = MessageType(41);
     /// `open_channel2` message (BOLT 2).
-    pub const OPEN_CHANNEL2: u16 = 64;
+    pub const OPEN_CHANNEL2: MessageType = MessageType(64);
     /// `accept_channel2` message (BOLT 2).
-    pub const ACCEPT_CHANNEL2: u16 = 65;
+    pub const ACCEPT_CHANNEL2: MessageType = MessageType(65);
     /// `tx_add_input` message (BOLT 2).
-    pub const TX_ADD_INPUT: u16 = 66;
+    pub const TX_ADD_INPUT: MessageType = MessageType(66);
     /// `tx_remove_input` message (BOLT 2).
-    pub const TX_REMOVE_INPUT: u16 = 68;
+    pub const TX_REMOVE_INPUT: MessageType = MessageType(68);
     /// `tx_remove_output` message (BOLT 2).
-    pub const TX_REMOVE_OUTPUT: u16 = 69;
+    pub const TX_REMOVE_OUTPUT: MessageType = MessageType(69);
     /// `tx_complete` message (BOLT 2).
-    pub const TX_COMPLETE: u16 = 70;
+    pub const TX_COMPLETE: MessageType = MessageType(70);
     /// `tx_init_rbf` message (BOLT 2).
-    pub const TX_INIT_RBF: u16 = 72;
+    pub const TX_INIT_RBF: MessageType = MessageType(72);
     /// `tx_ack_rbf` message (BOLT 2).
-    pub const TX_ACK_RBF: u16 = 73;
+    pub const TX_ACK_RBF: MessageType = MessageType(73);
     /// `tx_abort` message (BOLT 2).
-    pub const TX_ABORT: u16 = 74;
+    pub const TX_ABORT: MessageType = MessageType(74);
     /// `update_add_htlc` message (BOLT 2).
-    pub const UPDATE_ADD_HTLC: u16 = 128;
+    pub const UPDATE_ADD_HTLC: MessageType = MessageType(128);
     /// `update_fulfill_htlc` message (BOLT 2).
-    pub const UPDATE_FULFILL_HTLC: u16 = 130;
+    pub const UPDATE_FULFILL_HTLC: MessageType = MessageType(130);
     /// `update_fail_htlc` message (BOLT 2).
-    pub const UPDATE_FAIL_HTLC: u16 = 131;
+    pub const UPDATE_FAIL_HTLC: MessageType = MessageType(131);
     /// `commitment_signed` message (BOLT 2).
-    pub const COMMITMENT_SIGNED: u16 = 132;
+    pub const COMMITMENT_SIGNED: MessageType = MessageType(132);
     /// `revoke_and_ack` message (BOLT 2).
-    pub const REVOKE_AND_ACK: u16 = 133;
+    pub const REVOKE_AND_ACK: MessageType = MessageType(133);
     /// `update_fail_malformed_htlc` message (BOLT 2).
-    pub const UPDATE_FAIL_MALFORMED_HTLC: u16 = 135;
+    pub const UPDATE_FAIL_MALFORMED_HTLC: MessageType = MessageType(135);
     /// `channel_announcement` message (BOLT 7).
-    pub const CHANNEL_ANNOUNCEMENT: u16 = 256;
+    pub const CHANNEL_ANNOUNCEMENT: MessageType = MessageType(256);
     /// `node_announcement` message (BOLT 7).
-    pub const NODE_ANNOUNCEMENT: u16 = 257;
+    pub const NODE_ANNOUNCEMENT: MessageType = MessageType(257);
     /// `channel_update` message (BOLT 7).
-    pub const CHANNEL_UPDATE: u16 = 258;
+    pub const CHANNEL_UPDATE: MessageType = MessageType(258);
     /// `announcement_signatures` message (BOLT 7).
-    pub const ANNOUNCEMENT_SIGNATURES: u16 = 259;
+    pub const ANNOUNCEMENT_SIGNATURES: MessageType = MessageType(259);
     /// Gossip timestamp filter message (BOLT 7).
-    pub const GOSSIP_TIMESTAMP_FILTER: u16 = 265;
+    pub const GOSSIP_TIMESTAMP_FILTER: MessageType = MessageType(265);
+
+    /// Constructs a message type from its raw wire number.
+    #[must_use]
+    pub const fn from_u16(ty: u16) -> Self {
+        Self(ty)
+    }
+
+    /// Returns the raw wire number.
+    #[must_use]
+    pub const fn as_u16(self) -> u16 {
+        self.0
+    }
+
+    /// Returns the BOLT name for this message type (e.g. `open_channel`), or
+    /// `unknown` if the type is not recognized.
+    #[must_use]
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::WARNING => "warning",
+            Self::INIT => "init",
+            Self::ERROR => "error",
+            Self::PING => "ping",
+            Self::PONG => "pong",
+            Self::OPEN_CHANNEL => "open_channel",
+            Self::ACCEPT_CHANNEL => "accept_channel",
+            Self::FUNDING_CREATED => "funding_created",
+            Self::FUNDING_SIGNED => "funding_signed",
+            Self::CHANNEL_READY => "channel_ready",
+            Self::SHUTDOWN => "shutdown",
+            Self::CLOSING_COMPLETE => "closing_complete",
+            Self::CLOSING_SIG => "closing_sig",
+            Self::OPEN_CHANNEL2 => "open_channel2",
+            Self::ACCEPT_CHANNEL2 => "accept_channel2",
+            Self::TX_ADD_INPUT => "tx_add_input",
+            Self::TX_REMOVE_INPUT => "tx_remove_input",
+            Self::TX_REMOVE_OUTPUT => "tx_remove_output",
+            Self::TX_COMPLETE => "tx_complete",
+            Self::TX_INIT_RBF => "tx_init_rbf",
+            Self::TX_ACK_RBF => "tx_ack_rbf",
+            Self::TX_ABORT => "tx_abort",
+            Self::UPDATE_ADD_HTLC => "update_add_htlc",
+            Self::UPDATE_FULFILL_HTLC => "update_fulfill_htlc",
+            Self::UPDATE_FAIL_HTLC => "update_fail_htlc",
+            Self::COMMITMENT_SIGNED => "commitment_signed",
+            Self::REVOKE_AND_ACK => "revoke_and_ack",
+            Self::UPDATE_FAIL_MALFORMED_HTLC => "update_fail_malformed_htlc",
+            Self::CHANNEL_ANNOUNCEMENT => "channel_announcement",
+            Self::NODE_ANNOUNCEMENT => "node_announcement",
+            Self::CHANNEL_UPDATE => "channel_update",
+            Self::ANNOUNCEMENT_SIGNATURES => "announcement_signatures",
+            Self::GOSSIP_TIMESTAMP_FILTER => "gossip_timestamp_filter",
+            _ => "unknown",
+        }
+    }
+}
+
+impl std::fmt::Display for MessageType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}({})", self.name(), self.0)
+    }
 }
 
 /// A decoded BOLT message.
@@ -288,44 +352,44 @@ pub enum Message {
 }
 
 impl Message {
-    /// Returns the message type number.
+    /// Returns the message type.
     #[must_use]
-    pub fn msg_type(&self) -> u16 {
+    pub fn msg_type(&self) -> MessageType {
         match self {
-            Self::Warning(_) => msg_type::WARNING,
-            Self::Init(_) => msg_type::INIT,
-            Self::Error(_) => msg_type::ERROR,
-            Self::Ping(_) => msg_type::PING,
-            Self::Pong(_) => msg_type::PONG,
-            Self::OpenChannel(_) => msg_type::OPEN_CHANNEL,
-            Self::AcceptChannel(_) => msg_type::ACCEPT_CHANNEL,
-            Self::FundingCreated(_) => msg_type::FUNDING_CREATED,
-            Self::FundingSigned(_) => msg_type::FUNDING_SIGNED,
-            Self::ChannelReady(_) => msg_type::CHANNEL_READY,
-            Self::Shutdown(_) => msg_type::SHUTDOWN,
-            Self::ClosingComplete(_) => msg_type::CLOSING_COMPLETE,
-            Self::ClosingSig(_) => msg_type::CLOSING_SIG,
-            Self::OpenChannel2(_) => msg_type::OPEN_CHANNEL2,
-            Self::AcceptChannel2(_) => msg_type::ACCEPT_CHANNEL2,
-            Self::TxAddInput(_) => msg_type::TX_ADD_INPUT,
-            Self::TxRemoveInput(_) => msg_type::TX_REMOVE_INPUT,
-            Self::TxRemoveOutput(_) => msg_type::TX_REMOVE_OUTPUT,
-            Self::TxComplete(_) => msg_type::TX_COMPLETE,
-            Self::TxInitRbf(_) => msg_type::TX_INIT_RBF,
-            Self::TxAckRbf(_) => msg_type::TX_ACK_RBF,
-            Self::TxAbort(_) => msg_type::TX_ABORT,
-            Self::UpdateAddHtlc(_) => msg_type::UPDATE_ADD_HTLC,
-            Self::UpdateFulfillHtlc(_) => msg_type::UPDATE_FULFILL_HTLC,
-            Self::UpdateFailHtlc(_) => msg_type::UPDATE_FAIL_HTLC,
-            Self::CommitmentSigned(_) => msg_type::COMMITMENT_SIGNED,
-            Self::RevokeAndAck(_) => msg_type::REVOKE_AND_ACK,
-            Self::UpdateFailMalformedHtlc(_) => msg_type::UPDATE_FAIL_MALFORMED_HTLC,
-            Self::ChannelAnnouncement(_) => msg_type::CHANNEL_ANNOUNCEMENT,
-            Self::NodeAnnouncement(_) => msg_type::NODE_ANNOUNCEMENT,
-            Self::ChannelUpdate(_) => msg_type::CHANNEL_UPDATE,
-            Self::AnnouncementSignatures(_) => msg_type::ANNOUNCEMENT_SIGNATURES,
-            Self::GossipTimestampFilter(_) => msg_type::GOSSIP_TIMESTAMP_FILTER,
-            Self::Unknown { msg_type, .. } => *msg_type,
+            Self::Warning(_) => MessageType::WARNING,
+            Self::Init(_) => MessageType::INIT,
+            Self::Error(_) => MessageType::ERROR,
+            Self::Ping(_) => MessageType::PING,
+            Self::Pong(_) => MessageType::PONG,
+            Self::OpenChannel(_) => MessageType::OPEN_CHANNEL,
+            Self::AcceptChannel(_) => MessageType::ACCEPT_CHANNEL,
+            Self::FundingCreated(_) => MessageType::FUNDING_CREATED,
+            Self::FundingSigned(_) => MessageType::FUNDING_SIGNED,
+            Self::ChannelReady(_) => MessageType::CHANNEL_READY,
+            Self::Shutdown(_) => MessageType::SHUTDOWN,
+            Self::ClosingComplete(_) => MessageType::CLOSING_COMPLETE,
+            Self::ClosingSig(_) => MessageType::CLOSING_SIG,
+            Self::OpenChannel2(_) => MessageType::OPEN_CHANNEL2,
+            Self::AcceptChannel2(_) => MessageType::ACCEPT_CHANNEL2,
+            Self::TxAddInput(_) => MessageType::TX_ADD_INPUT,
+            Self::TxRemoveInput(_) => MessageType::TX_REMOVE_INPUT,
+            Self::TxRemoveOutput(_) => MessageType::TX_REMOVE_OUTPUT,
+            Self::TxComplete(_) => MessageType::TX_COMPLETE,
+            Self::TxInitRbf(_) => MessageType::TX_INIT_RBF,
+            Self::TxAckRbf(_) => MessageType::TX_ACK_RBF,
+            Self::TxAbort(_) => MessageType::TX_ABORT,
+            Self::UpdateAddHtlc(_) => MessageType::UPDATE_ADD_HTLC,
+            Self::UpdateFulfillHtlc(_) => MessageType::UPDATE_FULFILL_HTLC,
+            Self::UpdateFailHtlc(_) => MessageType::UPDATE_FAIL_HTLC,
+            Self::CommitmentSigned(_) => MessageType::COMMITMENT_SIGNED,
+            Self::RevokeAndAck(_) => MessageType::REVOKE_AND_ACK,
+            Self::UpdateFailMalformedHtlc(_) => MessageType::UPDATE_FAIL_MALFORMED_HTLC,
+            Self::ChannelAnnouncement(_) => MessageType::CHANNEL_ANNOUNCEMENT,
+            Self::NodeAnnouncement(_) => MessageType::NODE_ANNOUNCEMENT,
+            Self::ChannelUpdate(_) => MessageType::CHANNEL_UPDATE,
+            Self::AnnouncementSignatures(_) => MessageType::ANNOUNCEMENT_SIGNATURES,
+            Self::GossipTimestampFilter(_) => MessageType::GOSSIP_TIMESTAMP_FILTER,
+            Self::Unknown { msg_type, .. } => MessageType(*msg_type),
         }
     }
 
@@ -333,7 +397,7 @@ impl Message {
     #[must_use]
     pub fn encode(&self) -> Vec<u8> {
         let mut out = Vec::new();
-        self.msg_type().write(&mut out);
+        self.msg_type().as_u16().write(&mut out);
         match self {
             Self::Warning(m) => out.extend(m.encode()),
             Self::Init(m) => out.extend(m.encode()),
@@ -384,54 +448,62 @@ impl Message {
         let mut cursor = data;
         let msg_type = u16::read(&mut cursor)?;
 
-        match msg_type {
-            msg_type::WARNING => Ok(Self::Warning(Warning::decode(cursor)?)),
-            msg_type::INIT => Ok(Self::Init(Init::decode(cursor)?)),
-            msg_type::ERROR => Ok(Self::Error(Error::decode(cursor)?)),
-            msg_type::PING => Ok(Self::Ping(Ping::decode(cursor)?)),
-            msg_type::PONG => Ok(Self::Pong(Pong::decode(cursor)?)),
-            msg_type::OPEN_CHANNEL => Ok(Self::OpenChannel(OpenChannel::decode(cursor)?)),
-            msg_type::ACCEPT_CHANNEL => Ok(Self::AcceptChannel(AcceptChannel::decode(cursor)?)),
-            msg_type::FUNDING_CREATED => Ok(Self::FundingCreated(FundingCreated::decode(cursor)?)),
-            msg_type::FUNDING_SIGNED => Ok(Self::FundingSigned(FundingSigned::decode(cursor)?)),
-            msg_type::CHANNEL_READY => Ok(Self::ChannelReady(ChannelReady::decode(cursor)?)),
-            msg_type::SHUTDOWN => Ok(Self::Shutdown(Shutdown::decode(cursor)?)),
-            msg_type::CLOSING_COMPLETE => {
+        match MessageType(msg_type) {
+            MessageType::WARNING => Ok(Self::Warning(Warning::decode(cursor)?)),
+            MessageType::INIT => Ok(Self::Init(Init::decode(cursor)?)),
+            MessageType::ERROR => Ok(Self::Error(Error::decode(cursor)?)),
+            MessageType::PING => Ok(Self::Ping(Ping::decode(cursor)?)),
+            MessageType::PONG => Ok(Self::Pong(Pong::decode(cursor)?)),
+            MessageType::OPEN_CHANNEL => Ok(Self::OpenChannel(OpenChannel::decode(cursor)?)),
+            MessageType::ACCEPT_CHANNEL => Ok(Self::AcceptChannel(AcceptChannel::decode(cursor)?)),
+            MessageType::FUNDING_CREATED => {
+                Ok(Self::FundingCreated(FundingCreated::decode(cursor)?))
+            }
+            MessageType::FUNDING_SIGNED => Ok(Self::FundingSigned(FundingSigned::decode(cursor)?)),
+            MessageType::CHANNEL_READY => Ok(Self::ChannelReady(ChannelReady::decode(cursor)?)),
+            MessageType::SHUTDOWN => Ok(Self::Shutdown(Shutdown::decode(cursor)?)),
+            MessageType::CLOSING_COMPLETE => {
                 Ok(Self::ClosingComplete(ClosingComplete::decode(cursor)?))
             }
-            msg_type::CLOSING_SIG => Ok(Self::ClosingSig(ClosingSig::decode(cursor)?)),
-            msg_type::OPEN_CHANNEL2 => Ok(Self::OpenChannel2(OpenChannel2::decode(cursor)?)),
-            msg_type::ACCEPT_CHANNEL2 => Ok(Self::AcceptChannel2(AcceptChannel2::decode(cursor)?)),
-            msg_type::TX_ADD_INPUT => Ok(Self::TxAddInput(TxAddInput::decode(cursor)?)),
-            msg_type::TX_REMOVE_INPUT => Ok(Self::TxRemoveInput(TxRemoveInput::decode(cursor)?)),
-            msg_type::TX_REMOVE_OUTPUT => Ok(Self::TxRemoveOutput(TxRemoveOutput::decode(cursor)?)),
-            msg_type::TX_COMPLETE => Ok(Self::TxComplete(TxComplete::decode(cursor)?)),
-            msg_type::TX_INIT_RBF => Ok(Self::TxInitRbf(TxInitRbf::decode(cursor)?)),
-            msg_type::TX_ACK_RBF => Ok(Self::TxAckRbf(TxAckRbf::decode(cursor)?)),
-            msg_type::TX_ABORT => Ok(Self::TxAbort(TxAbort::decode(cursor)?)),
-            msg_type::UPDATE_ADD_HTLC => Ok(Self::UpdateAddHtlc(UpdateAddHtlc::decode(cursor)?)),
-            msg_type::UPDATE_FULFILL_HTLC => {
+            MessageType::CLOSING_SIG => Ok(Self::ClosingSig(ClosingSig::decode(cursor)?)),
+            MessageType::OPEN_CHANNEL2 => Ok(Self::OpenChannel2(OpenChannel2::decode(cursor)?)),
+            MessageType::ACCEPT_CHANNEL2 => {
+                Ok(Self::AcceptChannel2(AcceptChannel2::decode(cursor)?))
+            }
+            MessageType::TX_ADD_INPUT => Ok(Self::TxAddInput(TxAddInput::decode(cursor)?)),
+            MessageType::TX_REMOVE_INPUT => Ok(Self::TxRemoveInput(TxRemoveInput::decode(cursor)?)),
+            MessageType::TX_REMOVE_OUTPUT => {
+                Ok(Self::TxRemoveOutput(TxRemoveOutput::decode(cursor)?))
+            }
+            MessageType::TX_COMPLETE => Ok(Self::TxComplete(TxComplete::decode(cursor)?)),
+            MessageType::TX_INIT_RBF => Ok(Self::TxInitRbf(TxInitRbf::decode(cursor)?)),
+            MessageType::TX_ACK_RBF => Ok(Self::TxAckRbf(TxAckRbf::decode(cursor)?)),
+            MessageType::TX_ABORT => Ok(Self::TxAbort(TxAbort::decode(cursor)?)),
+            MessageType::UPDATE_ADD_HTLC => Ok(Self::UpdateAddHtlc(UpdateAddHtlc::decode(cursor)?)),
+            MessageType::UPDATE_FULFILL_HTLC => {
                 Ok(Self::UpdateFulfillHtlc(UpdateFulfillHtlc::decode(cursor)?))
             }
-            msg_type::UPDATE_FAIL_HTLC => Ok(Self::UpdateFailHtlc(UpdateFailHtlc::decode(cursor)?)),
-            msg_type::COMMITMENT_SIGNED => {
+            MessageType::UPDATE_FAIL_HTLC => {
+                Ok(Self::UpdateFailHtlc(UpdateFailHtlc::decode(cursor)?))
+            }
+            MessageType::COMMITMENT_SIGNED => {
                 Ok(Self::CommitmentSigned(CommitmentSigned::decode(cursor)?))
             }
-            msg_type::REVOKE_AND_ACK => Ok(Self::RevokeAndAck(RevokeAndAck::decode(cursor)?)),
-            msg_type::UPDATE_FAIL_MALFORMED_HTLC => Ok(Self::UpdateFailMalformedHtlc(
+            MessageType::REVOKE_AND_ACK => Ok(Self::RevokeAndAck(RevokeAndAck::decode(cursor)?)),
+            MessageType::UPDATE_FAIL_MALFORMED_HTLC => Ok(Self::UpdateFailMalformedHtlc(
                 UpdateFailMalformedHtlc::decode(cursor)?,
             )),
-            msg_type::CHANNEL_ANNOUNCEMENT => Ok(Self::ChannelAnnouncement(
+            MessageType::CHANNEL_ANNOUNCEMENT => Ok(Self::ChannelAnnouncement(
                 ChannelAnnouncement::decode(cursor)?,
             )),
-            msg_type::NODE_ANNOUNCEMENT => {
+            MessageType::NODE_ANNOUNCEMENT => {
                 Ok(Self::NodeAnnouncement(NodeAnnouncement::decode(cursor)?))
             }
-            msg_type::CHANNEL_UPDATE => Ok(Self::ChannelUpdate(ChannelUpdate::decode(cursor)?)),
-            msg_type::ANNOUNCEMENT_SIGNATURES => Ok(Self::AnnouncementSignatures(
+            MessageType::CHANNEL_UPDATE => Ok(Self::ChannelUpdate(ChannelUpdate::decode(cursor)?)),
+            MessageType::ANNOUNCEMENT_SIGNATURES => Ok(Self::AnnouncementSignatures(
                 AnnouncementSignatures::decode(cursor)?,
             )),
-            msg_type::GOSSIP_TIMESTAMP_FILTER => Ok(Self::GossipTimestampFilter(
+            MessageType::GOSSIP_TIMESTAMP_FILTER => Ok(Self::GossipTimestampFilter(
                 GossipTimestampFilter::decode(cursor)?,
             )),
             _ => {
@@ -1141,58 +1213,58 @@ mod tests {
     fn message_type_values() {
         assert_eq!(
             Message::Warning(Warning::all_channels("")).msg_type(),
-            msg_type::WARNING
+            MessageType::WARNING
         );
-        assert_eq!(Message::Init(Init::empty()).msg_type(), msg_type::INIT);
+        assert_eq!(Message::Init(Init::empty()).msg_type(), MessageType::INIT);
         assert_eq!(
             Message::Error(Error::all_channels("")).msg_type(),
-            msg_type::ERROR
+            MessageType::ERROR
         );
-        assert_eq!(Message::Ping(Ping::new(0)).msg_type(), msg_type::PING);
-        assert_eq!(Message::Pong(Pong::new(0)).msg_type(), msg_type::PONG);
+        assert_eq!(Message::Ping(Ping::new(0)).msg_type(), MessageType::PING);
+        assert_eq!(Message::Pong(Pong::new(0)).msg_type(), MessageType::PONG);
         assert_eq!(
             Message::OpenChannel(sample_open_channel()).msg_type(),
-            msg_type::OPEN_CHANNEL
+            MessageType::OPEN_CHANNEL
         );
         assert_eq!(
             Message::AcceptChannel(sample_accept_channel()).msg_type(),
-            msg_type::ACCEPT_CHANNEL
+            MessageType::ACCEPT_CHANNEL
         );
         assert_eq!(
             Message::FundingCreated(sample_funding_created()).msg_type(),
-            msg_type::FUNDING_CREATED
+            MessageType::FUNDING_CREATED
         );
         assert_eq!(
             Message::FundingSigned(sample_funding_signed()).msg_type(),
-            msg_type::FUNDING_SIGNED
+            MessageType::FUNDING_SIGNED
         );
         assert_eq!(
             Message::ChannelReady(sample_channel_ready()).msg_type(),
-            msg_type::CHANNEL_READY
+            MessageType::CHANNEL_READY
         );
         assert_eq!(
             Message::Shutdown(Shutdown::for_channel(ChannelId([0; 32]), vec![])).msg_type(),
-            msg_type::SHUTDOWN
+            MessageType::SHUTDOWN
         );
         assert_eq!(
             Message::ClosingComplete(sample_closing_complete()).msg_type(),
-            msg_type::CLOSING_COMPLETE,
+            MessageType::CLOSING_COMPLETE,
         );
         assert_eq!(
             Message::ClosingSig(sample_closing_sig()).msg_type(),
-            msg_type::CLOSING_SIG,
+            MessageType::CLOSING_SIG,
         );
         assert_eq!(
             Message::OpenChannel2(sample_open_channel2()).msg_type(),
-            msg_type::OPEN_CHANNEL2
+            MessageType::OPEN_CHANNEL2
         );
         assert_eq!(
             Message::AcceptChannel2(sample_accept_channel2(None)).msg_type(),
-            msg_type::ACCEPT_CHANNEL2
+            MessageType::ACCEPT_CHANNEL2
         );
         assert_eq!(
             Message::TxAddInput(sample_tx_add_input()).msg_type(),
-            msg_type::TX_ADD_INPUT
+            MessageType::TX_ADD_INPUT
         );
         assert_eq!(
             Message::TxRemoveInput(TxRemoveInput {
@@ -1200,7 +1272,7 @@ mod tests {
                 serial_id: 0
             })
             .msg_type(),
-            msg_type::TX_REMOVE_INPUT
+            MessageType::TX_REMOVE_INPUT
         );
         assert_eq!(
             Message::TxRemoveOutput(TxRemoveOutput {
@@ -1208,14 +1280,14 @@ mod tests {
                 serial_id: 0
             })
             .msg_type(),
-            msg_type::TX_REMOVE_OUTPUT
+            MessageType::TX_REMOVE_OUTPUT
         );
         assert_eq!(
             Message::TxComplete(TxComplete {
                 channel_id: ChannelId::new([0; CHANNEL_ID_SIZE])
             })
             .msg_type(),
-            msg_type::TX_COMPLETE
+            MessageType::TX_COMPLETE
         );
         assert_eq!(
             Message::TxInitRbf(TxInitRbf {
@@ -1225,7 +1297,7 @@ mod tests {
                 tlvs: TxInitRbfTlvs::default(),
             })
             .msg_type(),
-            msg_type::TX_INIT_RBF
+            MessageType::TX_INIT_RBF
         );
         assert_eq!(
             Message::TxAckRbf(TxAckRbf {
@@ -1233,15 +1305,15 @@ mod tests {
                 tlvs: TxAckRbfTlvs::default(),
             })
             .msg_type(),
-            msg_type::TX_ACK_RBF
+            MessageType::TX_ACK_RBF
         );
         assert_eq!(
             Message::TxAbort(TxAbort::new(ChannelId::new([0; CHANNEL_ID_SIZE]), "")).msg_type(),
-            msg_type::TX_ABORT
+            MessageType::TX_ABORT
         );
         assert_eq!(
             Message::UpdateAddHtlc(sample_update_add_htlc()).msg_type(),
-            msg_type::UPDATE_ADD_HTLC
+            MessageType::UPDATE_ADD_HTLC
         );
         assert_eq!(
             Message::UpdateFulfillHtlc(UpdateFulfillHtlc {
@@ -1251,7 +1323,7 @@ mod tests {
                 tlvs: UpdateFulfillHtlcTlvs::default(),
             })
             .msg_type(),
-            msg_type::UPDATE_FULFILL_HTLC
+            MessageType::UPDATE_FULFILL_HTLC
         );
         assert_eq!(
             Message::UpdateFailHtlc(UpdateFailHtlc {
@@ -1261,15 +1333,15 @@ mod tests {
                 tlvs: UpdateFailHtlcTlvs::default(),
             })
             .msg_type(),
-            msg_type::UPDATE_FAIL_HTLC
+            MessageType::UPDATE_FAIL_HTLC
         );
         assert_eq!(
             Message::CommitmentSigned(sample_commitment_signed()).msg_type(),
-            msg_type::COMMITMENT_SIGNED
+            MessageType::COMMITMENT_SIGNED
         );
         assert_eq!(
             Message::RevokeAndAck(sample_revoke_and_ack()).msg_type(),
-            msg_type::REVOKE_AND_ACK
+            MessageType::REVOKE_AND_ACK
         );
         assert_eq!(
             Message::UpdateFailMalformedHtlc(UpdateFailMalformedHtlc {
@@ -1279,27 +1351,27 @@ mod tests {
                 failure_code: 0x8001,
             })
             .msg_type(),
-            msg_type::UPDATE_FAIL_MALFORMED_HTLC
+            MessageType::UPDATE_FAIL_MALFORMED_HTLC
         );
         assert_eq!(
             Message::ChannelAnnouncement(sample_channel_announcement()).msg_type(),
-            msg_type::CHANNEL_ANNOUNCEMENT
+            MessageType::CHANNEL_ANNOUNCEMENT
         );
         assert_eq!(
             Message::NodeAnnouncement(sample_node_announcement()).msg_type(),
-            msg_type::NODE_ANNOUNCEMENT
+            MessageType::NODE_ANNOUNCEMENT
         );
         assert_eq!(
             Message::ChannelUpdate(sample_channel_update()).msg_type(),
-            msg_type::CHANNEL_UPDATE
+            MessageType::CHANNEL_UPDATE
         );
         assert_eq!(
             Message::AnnouncementSignatures(sample_announcement_signatures()).msg_type(),
-            msg_type::ANNOUNCEMENT_SIGNATURES
+            MessageType::ANNOUNCEMENT_SIGNATURES
         );
         assert_eq!(
             Message::GossipTimestampFilter(GossipTimestampFilter::no_gossip([0u8; 32])).msg_type(),
-            msg_type::GOSSIP_TIMESTAMP_FILTER
+            MessageType::GOSSIP_TIMESTAMP_FILTER
         );
         assert_eq!(
             Message::Unknown {
@@ -1307,7 +1379,7 @@ mod tests {
                 payload: vec![]
             }
             .msg_type(),
-            99
+            MessageType(99)
         );
     }
 
@@ -1346,7 +1418,7 @@ mod tests {
 
     #[test]
     fn message_with_type_helper() {
-        let data = message_with_type(msg_type::PING, &[0x00, 0x04, 0x00, 0x00]);
+        let data = message_with_type(MessageType::PING.as_u16(), &[0x00, 0x04, 0x00, 0x00]);
         assert_eq!(data, [0x00, 0x12, 0x00, 0x04, 0x00, 0x00]); // 0x12 = 18 = PING
     }
 }

--- a/smite/src/bolt.rs
+++ b/smite/src/bolt.rs
@@ -345,10 +345,16 @@ pub enum Message {
     /// Even unknown types cause decode to fail.
     Unknown {
         /// The message type.
-        msg_type: u16,
+        msg_type: MessageType,
         /// The raw payload (without type prefix).
         payload: Vec<u8>,
     },
+}
+
+impl std::fmt::Display for Message {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.msg_type())
+    }
 }
 
 impl Message {
@@ -389,7 +395,7 @@ impl Message {
             Self::ChannelUpdate(_) => MessageType::CHANNEL_UPDATE,
             Self::AnnouncementSignatures(_) => MessageType::ANNOUNCEMENT_SIGNATURES,
             Self::GossipTimestampFilter(_) => MessageType::GOSSIP_TIMESTAMP_FILTER,
-            Self::Unknown { msg_type, .. } => MessageType(*msg_type),
+            Self::Unknown { msg_type, .. } => *msg_type,
         }
     }
 
@@ -448,7 +454,7 @@ impl Message {
         let mut cursor = data;
         let msg_type = u16::read(&mut cursor)?;
 
-        match MessageType(msg_type) {
+        match MessageType::from_u16(msg_type) {
             MessageType::WARNING => Ok(Self::Warning(Warning::decode(cursor)?)),
             MessageType::INIT => Ok(Self::Init(Init::decode(cursor)?)),
             MessageType::ERROR => Ok(Self::Error(Error::decode(cursor)?)),
@@ -512,7 +518,7 @@ impl Message {
                     Err(BoltError::UnknownEvenType(msg_type))
                 } else {
                     Ok(Self::Unknown {
-                        msg_type,
+                        msg_type: MessageType::from_u16(msg_type),
                         payload: cursor.to_vec(),
                     })
                 }
@@ -526,9 +532,9 @@ impl Message {
 /// This is useful for fuzzing - it allows sending arbitrary payloads
 /// with any message type, bypassing normal encoding.
 #[must_use]
-pub fn message_with_type(msg_type: u16, payload: &[u8]) -> Vec<u8> {
+pub fn message_with_type(msg_type: MessageType, payload: &[u8]) -> Vec<u8> {
     let mut out = Vec::new();
-    msg_type.write(&mut out);
+    msg_type.as_u16().write(&mut out);
     out.extend_from_slice(payload);
     out
 }
@@ -1200,7 +1206,7 @@ mod tests {
     #[test]
     fn message_unknown_roundtrip() {
         let msg = Message::Unknown {
-            msg_type: 101,
+            msg_type: MessageType::from_u16(101),
             payload: vec![0x11, 0x22, 0x33],
         };
         let encoded = msg.encode();
@@ -1211,187 +1217,217 @@ mod tests {
     #[allow(clippy::too_many_lines)]
     #[test]
     fn message_type_values() {
-        assert_eq!(
-            Message::Warning(Warning::all_channels("")).msg_type(),
-            MessageType::WARNING
-        );
-        assert_eq!(Message::Init(Init::empty()).msg_type(), MessageType::INIT);
-        assert_eq!(
-            Message::Error(Error::all_channels("")).msg_type(),
-            MessageType::ERROR
-        );
-        assert_eq!(Message::Ping(Ping::new(0)).msg_type(), MessageType::PING);
-        assert_eq!(Message::Pong(Pong::new(0)).msg_type(), MessageType::PONG);
-        assert_eq!(
-            Message::OpenChannel(sample_open_channel()).msg_type(),
-            MessageType::OPEN_CHANNEL
-        );
-        assert_eq!(
-            Message::AcceptChannel(sample_accept_channel()).msg_type(),
-            MessageType::ACCEPT_CHANNEL
-        );
-        assert_eq!(
-            Message::FundingCreated(sample_funding_created()).msg_type(),
-            MessageType::FUNDING_CREATED
-        );
-        assert_eq!(
-            Message::FundingSigned(sample_funding_signed()).msg_type(),
-            MessageType::FUNDING_SIGNED
-        );
-        assert_eq!(
-            Message::ChannelReady(sample_channel_ready()).msg_type(),
-            MessageType::CHANNEL_READY
-        );
-        assert_eq!(
-            Message::Shutdown(Shutdown::for_channel(ChannelId([0; 32]), vec![])).msg_type(),
-            MessageType::SHUTDOWN
-        );
-        assert_eq!(
-            Message::ClosingComplete(sample_closing_complete()).msg_type(),
-            MessageType::CLOSING_COMPLETE,
-        );
-        assert_eq!(
-            Message::ClosingSig(sample_closing_sig()).msg_type(),
-            MessageType::CLOSING_SIG,
-        );
-        assert_eq!(
-            Message::OpenChannel2(sample_open_channel2()).msg_type(),
-            MessageType::OPEN_CHANNEL2
-        );
-        assert_eq!(
-            Message::AcceptChannel2(sample_accept_channel2(None)).msg_type(),
-            MessageType::ACCEPT_CHANNEL2
-        );
-        assert_eq!(
-            Message::TxAddInput(sample_tx_add_input()).msg_type(),
-            MessageType::TX_ADD_INPUT
-        );
-        assert_eq!(
-            Message::TxRemoveInput(TxRemoveInput {
-                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
-                serial_id: 0
-            })
-            .msg_type(),
-            MessageType::TX_REMOVE_INPUT
-        );
-        assert_eq!(
-            Message::TxRemoveOutput(TxRemoveOutput {
-                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
-                serial_id: 0
-            })
-            .msg_type(),
-            MessageType::TX_REMOVE_OUTPUT
-        );
-        assert_eq!(
-            Message::TxComplete(TxComplete {
-                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE])
-            })
-            .msg_type(),
-            MessageType::TX_COMPLETE
-        );
-        assert_eq!(
-            Message::TxInitRbf(TxInitRbf {
-                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
-                locktime: 0,
-                feerate: 0,
-                tlvs: TxInitRbfTlvs::default(),
-            })
-            .msg_type(),
-            MessageType::TX_INIT_RBF
-        );
-        assert_eq!(
-            Message::TxAckRbf(TxAckRbf {
-                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
-                tlvs: TxAckRbfTlvs::default(),
-            })
-            .msg_type(),
-            MessageType::TX_ACK_RBF
-        );
-        assert_eq!(
-            Message::TxAbort(TxAbort::new(ChannelId::new([0; CHANNEL_ID_SIZE]), "")).msg_type(),
-            MessageType::TX_ABORT
-        );
-        assert_eq!(
-            Message::UpdateAddHtlc(sample_update_add_htlc()).msg_type(),
-            MessageType::UPDATE_ADD_HTLC
-        );
-        assert_eq!(
-            Message::UpdateFulfillHtlc(UpdateFulfillHtlc {
-                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
-                id: 0,
-                payment_preimage: [0; 32],
-                tlvs: UpdateFulfillHtlcTlvs::default(),
-            })
-            .msg_type(),
-            MessageType::UPDATE_FULFILL_HTLC
-        );
-        assert_eq!(
-            Message::UpdateFailHtlc(UpdateFailHtlc {
-                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
-                id: 0,
-                reason: vec![],
-                tlvs: UpdateFailHtlcTlvs::default(),
-            })
-            .msg_type(),
-            MessageType::UPDATE_FAIL_HTLC
-        );
-        assert_eq!(
-            Message::CommitmentSigned(sample_commitment_signed()).msg_type(),
-            MessageType::COMMITMENT_SIGNED
-        );
-        assert_eq!(
-            Message::RevokeAndAck(sample_revoke_and_ack()).msg_type(),
-            MessageType::REVOKE_AND_ACK
-        );
-        assert_eq!(
-            Message::UpdateFailMalformedHtlc(UpdateFailMalformedHtlc {
-                channel_id: ChannelId::new([0x42; CHANNEL_ID_SIZE]),
-                id: 12345,
-                sha256_of_onion: sha256::Hash::from_byte_array([0xaa; SHA256_HASH_SIZE]),
-                failure_code: 0x8001,
-            })
-            .msg_type(),
-            MessageType::UPDATE_FAIL_MALFORMED_HTLC
-        );
-        assert_eq!(
-            Message::ChannelAnnouncement(sample_channel_announcement()).msg_type(),
-            MessageType::CHANNEL_ANNOUNCEMENT
-        );
-        assert_eq!(
-            Message::NodeAnnouncement(sample_node_announcement()).msg_type(),
-            MessageType::NODE_ANNOUNCEMENT
-        );
-        assert_eq!(
-            Message::ChannelUpdate(sample_channel_update()).msg_type(),
-            MessageType::CHANNEL_UPDATE
-        );
-        assert_eq!(
-            Message::AnnouncementSignatures(sample_announcement_signatures()).msg_type(),
-            MessageType::ANNOUNCEMENT_SIGNATURES
-        );
-        assert_eq!(
-            Message::GossipTimestampFilter(GossipTimestampFilter::no_gossip([0u8; 32])).msg_type(),
-            MessageType::GOSSIP_TIMESTAMP_FILTER
-        );
-        assert_eq!(
-            Message::Unknown {
-                msg_type: 99,
-                payload: vec![]
-            }
-            .msg_type(),
-            MessageType(99)
-        );
+        let cases = vec![
+            (
+                Message::Warning(Warning::all_channels("")),
+                "warning",
+                MessageType::WARNING,
+            ),
+            (Message::Init(Init::empty()), "init", MessageType::INIT),
+            (
+                Message::Error(Error::all_channels("")),
+                "error",
+                MessageType::ERROR,
+            ),
+            (Message::Ping(Ping::new(0)), "ping", MessageType::PING),
+            (Message::Pong(Pong::new(0)), "pong", MessageType::PONG),
+            (
+                Message::OpenChannel(sample_open_channel()),
+                "open_channel",
+                MessageType::OPEN_CHANNEL,
+            ),
+            (
+                Message::AcceptChannel(sample_accept_channel()),
+                "accept_channel",
+                MessageType::ACCEPT_CHANNEL,
+            ),
+            (
+                Message::FundingCreated(sample_funding_created()),
+                "funding_created",
+                MessageType::FUNDING_CREATED,
+            ),
+            (
+                Message::FundingSigned(sample_funding_signed()),
+                "funding_signed",
+                MessageType::FUNDING_SIGNED,
+            ),
+            (
+                Message::ChannelReady(sample_channel_ready()),
+                "channel_ready",
+                MessageType::CHANNEL_READY,
+            ),
+            (
+                Message::Shutdown(Shutdown::for_channel(ChannelId([0; 32]), vec![])),
+                "shutdown",
+                MessageType::SHUTDOWN,
+            ),
+            (
+                Message::ClosingComplete(sample_closing_complete()),
+                "closing_complete",
+                MessageType::CLOSING_COMPLETE,
+            ),
+            (
+                Message::ClosingSig(sample_closing_sig()),
+                "closing_sig",
+                MessageType::CLOSING_SIG,
+            ),
+            (
+                Message::OpenChannel2(sample_open_channel2()),
+                "open_channel2",
+                MessageType::OPEN_CHANNEL2,
+            ),
+            (
+                Message::AcceptChannel2(sample_accept_channel2(None)),
+                "accept_channel2",
+                MessageType::ACCEPT_CHANNEL2,
+            ),
+            (
+                Message::TxAddInput(sample_tx_add_input()),
+                "tx_add_input",
+                MessageType::TX_ADD_INPUT,
+            ),
+            (
+                Message::TxRemoveInput(TxRemoveInput {
+                    channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                    serial_id: 0,
+                }),
+                "tx_remove_input",
+                MessageType::TX_REMOVE_INPUT,
+            ),
+            (
+                Message::TxRemoveOutput(TxRemoveOutput {
+                    channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                    serial_id: 0,
+                }),
+                "tx_remove_output",
+                MessageType::TX_REMOVE_OUTPUT,
+            ),
+            (
+                Message::TxComplete(TxComplete {
+                    channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                }),
+                "tx_complete",
+                MessageType::TX_COMPLETE,
+            ),
+            (
+                Message::TxInitRbf(TxInitRbf {
+                    channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                    locktime: 0,
+                    feerate: 0,
+                    tlvs: TxInitRbfTlvs::default(),
+                }),
+                "tx_init_rbf",
+                MessageType::TX_INIT_RBF,
+            ),
+            (
+                Message::TxAckRbf(TxAckRbf {
+                    channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                    tlvs: TxAckRbfTlvs::default(),
+                }),
+                "tx_ack_rbf",
+                MessageType::TX_ACK_RBF,
+            ),
+            (
+                Message::TxAbort(TxAbort::new(ChannelId::new([0; CHANNEL_ID_SIZE]), "")),
+                "tx_abort",
+                MessageType::TX_ABORT,
+            ),
+            (
+                Message::UpdateAddHtlc(sample_update_add_htlc()),
+                "update_add_htlc",
+                MessageType::UPDATE_ADD_HTLC,
+            ),
+            (
+                Message::UpdateFulfillHtlc(UpdateFulfillHtlc {
+                    channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                    id: 0,
+                    payment_preimage: [0; 32],
+                    tlvs: UpdateFulfillHtlcTlvs::default(),
+                }),
+                "update_fulfill_htlc",
+                MessageType::UPDATE_FULFILL_HTLC,
+            ),
+            (
+                Message::UpdateFailHtlc(UpdateFailHtlc {
+                    channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                    id: 0,
+                    reason: vec![],
+                    tlvs: UpdateFailHtlcTlvs::default(),
+                }),
+                "update_fail_htlc",
+                MessageType::UPDATE_FAIL_HTLC,
+            ),
+            (
+                Message::CommitmentSigned(sample_commitment_signed()),
+                "commitment_signed",
+                MessageType::COMMITMENT_SIGNED,
+            ),
+            (
+                Message::RevokeAndAck(sample_revoke_and_ack()),
+                "revoke_and_ack",
+                MessageType::REVOKE_AND_ACK,
+            ),
+            (
+                Message::UpdateFailMalformedHtlc(UpdateFailMalformedHtlc {
+                    channel_id: ChannelId::new([0x42; CHANNEL_ID_SIZE]),
+                    id: 12345,
+                    sha256_of_onion: sha256::Hash::from_byte_array([0xaa; SHA256_HASH_SIZE]),
+                    failure_code: 0x8001,
+                }),
+                "update_fail_malformed_htlc",
+                MessageType::UPDATE_FAIL_MALFORMED_HTLC,
+            ),
+            (
+                Message::ChannelAnnouncement(sample_channel_announcement()),
+                "channel_announcement",
+                MessageType::CHANNEL_ANNOUNCEMENT,
+            ),
+            (
+                Message::NodeAnnouncement(sample_node_announcement()),
+                "node_announcement",
+                MessageType::NODE_ANNOUNCEMENT,
+            ),
+            (
+                Message::ChannelUpdate(sample_channel_update()),
+                "channel_update",
+                MessageType::CHANNEL_UPDATE,
+            ),
+            (
+                Message::AnnouncementSignatures(sample_announcement_signatures()),
+                "announcement_signatures",
+                MessageType::ANNOUNCEMENT_SIGNATURES,
+            ),
+            (
+                Message::GossipTimestampFilter(GossipTimestampFilter::no_gossip([0u8; 32])),
+                "gossip_timestamp_filter",
+                MessageType::GOSSIP_TIMESTAMP_FILTER,
+            ),
+            (
+                Message::Unknown {
+                    msg_type: MessageType::from_u16(99),
+                    payload: vec![],
+                },
+                "unknown",
+                MessageType::from_u16(99),
+            ),
+        ];
+        for (msg, name, ty) in cases {
+            assert_eq!(msg.msg_type(), ty, "wrong type number for {name}");
+            assert_eq!(msg.msg_type().name(), name, "wrong type name for {ty}");
+            assert_eq!(msg.to_string(), format!("{name}({})", ty.as_u16()));
+            assert_eq!(msg.to_string(), ty.to_string());
+        }
     }
 
     #[test]
     fn message_decode_unknown_odd() {
         // Type 99 is odd and unknown - should be accepted
-        let data = message_with_type(99, &[0xaa, 0xbb]);
+        let data = message_with_type(MessageType::from_u16(99), &[0xaa, 0xbb]);
         let msg = Message::decode(&data).unwrap();
         assert_eq!(
             msg,
             Message::Unknown {
-                msg_type: 99,
+                msg_type: MessageType::from_u16(99),
                 payload: vec![0xaa, 0xbb]
             }
         );
@@ -1400,7 +1436,7 @@ mod tests {
     #[test]
     fn message_decode_unknown_even() {
         // Type 100 is even and unknown - should be rejected
-        let data = message_with_type(100, &[0xaa, 0xbb]);
+        let data = message_with_type(MessageType::from_u16(100), &[0xaa, 0xbb]);
         assert_eq!(Message::decode(&data), Err(BoltError::UnknownEvenType(100)));
     }
 
@@ -1418,7 +1454,7 @@ mod tests {
 
     #[test]
     fn message_with_type_helper() {
-        let data = message_with_type(MessageType::PING.as_u16(), &[0x00, 0x04, 0x00, 0x00]);
+        let data = message_with_type(MessageType::PING, &[0x00, 0x04, 0x00, 0x00]);
         assert_eq!(data, [0x00, 0x12, 0x00, 0x04, 0x00, 0x00]); // 0x12 = 18 = PING
     }
 }

--- a/smite/src/bolt.rs
+++ b/smite/src/bolt.rs
@@ -351,6 +351,12 @@ pub enum Message {
     },
 }
 
+impl std::fmt::Display for Message {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.msg_type())
+    }
+}
+
 impl Message {
     /// Returns the message type.
     #[must_use]
@@ -391,6 +397,13 @@ impl Message {
             Self::GossipTimestampFilter(_) => MessageType::GOSSIP_TIMESTAMP_FILTER,
             Self::Unknown { msg_type, .. } => MessageType(*msg_type),
         }
+    }
+
+    /// Returns the message type name (e.g. `open_channel`), or `unknown` for an
+    /// unrecognized type.
+    #[must_use]
+    pub fn msg_name(&self) -> &'static str {
+        self.msg_type().name()
     }
 
     /// Encodes to wire format (with 2-byte message type prefix).
@@ -1211,176 +1224,206 @@ mod tests {
     #[allow(clippy::too_many_lines)]
     #[test]
     fn message_type_values() {
-        assert_eq!(
-            Message::Warning(Warning::all_channels("")).msg_type(),
-            MessageType::WARNING
-        );
-        assert_eq!(Message::Init(Init::empty()).msg_type(), MessageType::INIT);
-        assert_eq!(
-            Message::Error(Error::all_channels("")).msg_type(),
-            MessageType::ERROR
-        );
-        assert_eq!(Message::Ping(Ping::new(0)).msg_type(), MessageType::PING);
-        assert_eq!(Message::Pong(Pong::new(0)).msg_type(), MessageType::PONG);
-        assert_eq!(
-            Message::OpenChannel(sample_open_channel()).msg_type(),
-            MessageType::OPEN_CHANNEL
-        );
-        assert_eq!(
-            Message::AcceptChannel(sample_accept_channel()).msg_type(),
-            MessageType::ACCEPT_CHANNEL
-        );
-        assert_eq!(
-            Message::FundingCreated(sample_funding_created()).msg_type(),
-            MessageType::FUNDING_CREATED
-        );
-        assert_eq!(
-            Message::FundingSigned(sample_funding_signed()).msg_type(),
-            MessageType::FUNDING_SIGNED
-        );
-        assert_eq!(
-            Message::ChannelReady(sample_channel_ready()).msg_type(),
-            MessageType::CHANNEL_READY
-        );
-        assert_eq!(
-            Message::Shutdown(Shutdown::for_channel(ChannelId([0; 32]), vec![])).msg_type(),
-            MessageType::SHUTDOWN
-        );
-        assert_eq!(
-            Message::ClosingComplete(sample_closing_complete()).msg_type(),
-            MessageType::CLOSING_COMPLETE,
-        );
-        assert_eq!(
-            Message::ClosingSig(sample_closing_sig()).msg_type(),
-            MessageType::CLOSING_SIG,
-        );
-        assert_eq!(
-            Message::OpenChannel2(sample_open_channel2()).msg_type(),
-            MessageType::OPEN_CHANNEL2
-        );
-        assert_eq!(
-            Message::AcceptChannel2(sample_accept_channel2(None)).msg_type(),
-            MessageType::ACCEPT_CHANNEL2
-        );
-        assert_eq!(
-            Message::TxAddInput(sample_tx_add_input()).msg_type(),
-            MessageType::TX_ADD_INPUT
-        );
-        assert_eq!(
-            Message::TxRemoveInput(TxRemoveInput {
-                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
-                serial_id: 0
-            })
-            .msg_type(),
-            MessageType::TX_REMOVE_INPUT
-        );
-        assert_eq!(
-            Message::TxRemoveOutput(TxRemoveOutput {
-                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
-                serial_id: 0
-            })
-            .msg_type(),
-            MessageType::TX_REMOVE_OUTPUT
-        );
-        assert_eq!(
-            Message::TxComplete(TxComplete {
-                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE])
-            })
-            .msg_type(),
-            MessageType::TX_COMPLETE
-        );
-        assert_eq!(
-            Message::TxInitRbf(TxInitRbf {
-                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
-                locktime: 0,
-                feerate: 0,
-                tlvs: TxInitRbfTlvs::default(),
-            })
-            .msg_type(),
-            MessageType::TX_INIT_RBF
-        );
-        assert_eq!(
-            Message::TxAckRbf(TxAckRbf {
-                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
-                tlvs: TxAckRbfTlvs::default(),
-            })
-            .msg_type(),
-            MessageType::TX_ACK_RBF
-        );
-        assert_eq!(
-            Message::TxAbort(TxAbort::new(ChannelId::new([0; CHANNEL_ID_SIZE]), "")).msg_type(),
-            MessageType::TX_ABORT
-        );
-        assert_eq!(
-            Message::UpdateAddHtlc(sample_update_add_htlc()).msg_type(),
-            MessageType::UPDATE_ADD_HTLC
-        );
-        assert_eq!(
-            Message::UpdateFulfillHtlc(UpdateFulfillHtlc {
-                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
-                id: 0,
-                payment_preimage: [0; 32],
-                tlvs: UpdateFulfillHtlcTlvs::default(),
-            })
-            .msg_type(),
-            MessageType::UPDATE_FULFILL_HTLC
-        );
-        assert_eq!(
-            Message::UpdateFailHtlc(UpdateFailHtlc {
-                channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
-                id: 0,
-                reason: vec![],
-                tlvs: UpdateFailHtlcTlvs::default(),
-            })
-            .msg_type(),
-            MessageType::UPDATE_FAIL_HTLC
-        );
-        assert_eq!(
-            Message::CommitmentSigned(sample_commitment_signed()).msg_type(),
-            MessageType::COMMITMENT_SIGNED
-        );
-        assert_eq!(
-            Message::RevokeAndAck(sample_revoke_and_ack()).msg_type(),
-            MessageType::REVOKE_AND_ACK
-        );
-        assert_eq!(
-            Message::UpdateFailMalformedHtlc(UpdateFailMalformedHtlc {
-                channel_id: ChannelId::new([0x42; CHANNEL_ID_SIZE]),
-                id: 12345,
-                sha256_of_onion: sha256::Hash::from_byte_array([0xaa; SHA256_HASH_SIZE]),
-                failure_code: 0x8001,
-            })
-            .msg_type(),
-            MessageType::UPDATE_FAIL_MALFORMED_HTLC
-        );
-        assert_eq!(
-            Message::ChannelAnnouncement(sample_channel_announcement()).msg_type(),
-            MessageType::CHANNEL_ANNOUNCEMENT
-        );
-        assert_eq!(
-            Message::NodeAnnouncement(sample_node_announcement()).msg_type(),
-            MessageType::NODE_ANNOUNCEMENT
-        );
-        assert_eq!(
-            Message::ChannelUpdate(sample_channel_update()).msg_type(),
-            MessageType::CHANNEL_UPDATE
-        );
-        assert_eq!(
-            Message::AnnouncementSignatures(sample_announcement_signatures()).msg_type(),
-            MessageType::ANNOUNCEMENT_SIGNATURES
-        );
-        assert_eq!(
-            Message::GossipTimestampFilter(GossipTimestampFilter::no_gossip([0u8; 32])).msg_type(),
-            MessageType::GOSSIP_TIMESTAMP_FILTER
-        );
-        assert_eq!(
-            Message::Unknown {
-                msg_type: 99,
-                payload: vec![]
-            }
-            .msg_type(),
-            MessageType(99)
-        );
+        let cases = vec![
+            (
+                Message::Warning(Warning::all_channels("")),
+                "warning",
+                MessageType::WARNING,
+            ),
+            (Message::Init(Init::empty()), "init", MessageType::INIT),
+            (
+                Message::Error(Error::all_channels("")),
+                "error",
+                MessageType::ERROR,
+            ),
+            (Message::Ping(Ping::new(0)), "ping", MessageType::PING),
+            (Message::Pong(Pong::new(0)), "pong", MessageType::PONG),
+            (
+                Message::OpenChannel(sample_open_channel()),
+                "open_channel",
+                MessageType::OPEN_CHANNEL,
+            ),
+            (
+                Message::AcceptChannel(sample_accept_channel()),
+                "accept_channel",
+                MessageType::ACCEPT_CHANNEL,
+            ),
+            (
+                Message::FundingCreated(sample_funding_created()),
+                "funding_created",
+                MessageType::FUNDING_CREATED,
+            ),
+            (
+                Message::FundingSigned(sample_funding_signed()),
+                "funding_signed",
+                MessageType::FUNDING_SIGNED,
+            ),
+            (
+                Message::ChannelReady(sample_channel_ready()),
+                "channel_ready",
+                MessageType::CHANNEL_READY,
+            ),
+            (
+                Message::Shutdown(Shutdown::for_channel(ChannelId([0; 32]), vec![])),
+                "shutdown",
+                MessageType::SHUTDOWN,
+            ),
+            (
+                Message::ClosingComplete(sample_closing_complete()),
+                "closing_complete",
+                MessageType::CLOSING_COMPLETE,
+            ),
+            (
+                Message::ClosingSig(sample_closing_sig()),
+                "closing_sig",
+                MessageType::CLOSING_SIG,
+            ),
+            (
+                Message::OpenChannel2(sample_open_channel2()),
+                "open_channel2",
+                MessageType::OPEN_CHANNEL2,
+            ),
+            (
+                Message::AcceptChannel2(sample_accept_channel2(None)),
+                "accept_channel2",
+                MessageType::ACCEPT_CHANNEL2,
+            ),
+            (
+                Message::TxAddInput(sample_tx_add_input()),
+                "tx_add_input",
+                MessageType::TX_ADD_INPUT,
+            ),
+            (
+                Message::TxRemoveInput(TxRemoveInput {
+                    channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                    serial_id: 0,
+                }),
+                "tx_remove_input",
+                MessageType::TX_REMOVE_INPUT,
+            ),
+            (
+                Message::TxRemoveOutput(TxRemoveOutput {
+                    channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                    serial_id: 0,
+                }),
+                "tx_remove_output",
+                MessageType::TX_REMOVE_OUTPUT,
+            ),
+            (
+                Message::TxComplete(TxComplete {
+                    channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                }),
+                "tx_complete",
+                MessageType::TX_COMPLETE,
+            ),
+            (
+                Message::TxInitRbf(TxInitRbf {
+                    channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                    locktime: 0,
+                    feerate: 0,
+                    tlvs: TxInitRbfTlvs::default(),
+                }),
+                "tx_init_rbf",
+                MessageType::TX_INIT_RBF,
+            ),
+            (
+                Message::TxAckRbf(TxAckRbf {
+                    channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                    tlvs: TxAckRbfTlvs::default(),
+                }),
+                "tx_ack_rbf",
+                MessageType::TX_ACK_RBF,
+            ),
+            (
+                Message::TxAbort(TxAbort::new(ChannelId::new([0; CHANNEL_ID_SIZE]), "")),
+                "tx_abort",
+                MessageType::TX_ABORT,
+            ),
+            (
+                Message::UpdateAddHtlc(sample_update_add_htlc()),
+                "update_add_htlc",
+                MessageType::UPDATE_ADD_HTLC,
+            ),
+            (
+                Message::UpdateFulfillHtlc(UpdateFulfillHtlc {
+                    channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                    id: 0,
+                    payment_preimage: [0; 32],
+                    tlvs: UpdateFulfillHtlcTlvs::default(),
+                }),
+                "update_fulfill_htlc",
+                MessageType::UPDATE_FULFILL_HTLC,
+            ),
+            (
+                Message::UpdateFailHtlc(UpdateFailHtlc {
+                    channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                    id: 0,
+                    reason: vec![],
+                    tlvs: UpdateFailHtlcTlvs::default(),
+                }),
+                "update_fail_htlc",
+                MessageType::UPDATE_FAIL_HTLC,
+            ),
+            (
+                Message::CommitmentSigned(sample_commitment_signed()),
+                "commitment_signed",
+                MessageType::COMMITMENT_SIGNED,
+            ),
+            (
+                Message::RevokeAndAck(sample_revoke_and_ack()),
+                "revoke_and_ack",
+                MessageType::REVOKE_AND_ACK,
+            ),
+            (
+                Message::UpdateFailMalformedHtlc(UpdateFailMalformedHtlc {
+                    channel_id: ChannelId::new([0x42; CHANNEL_ID_SIZE]),
+                    id: 12345,
+                    sha256_of_onion: sha256::Hash::from_byte_array([0xaa; SHA256_HASH_SIZE]),
+                    failure_code: 0x8001,
+                }),
+                "update_fail_malformed_htlc",
+                MessageType::UPDATE_FAIL_MALFORMED_HTLC,
+            ),
+            (
+                Message::ChannelAnnouncement(sample_channel_announcement()),
+                "channel_announcement",
+                MessageType::CHANNEL_ANNOUNCEMENT,
+            ),
+            (
+                Message::NodeAnnouncement(sample_node_announcement()),
+                "node_announcement",
+                MessageType::NODE_ANNOUNCEMENT,
+            ),
+            (
+                Message::ChannelUpdate(sample_channel_update()),
+                "channel_update",
+                MessageType::CHANNEL_UPDATE,
+            ),
+            (
+                Message::AnnouncementSignatures(sample_announcement_signatures()),
+                "announcement_signatures",
+                MessageType::ANNOUNCEMENT_SIGNATURES,
+            ),
+            (
+                Message::GossipTimestampFilter(GossipTimestampFilter::no_gossip([0u8; 32])),
+                "gossip_timestamp_filter",
+                MessageType::GOSSIP_TIMESTAMP_FILTER,
+            ),
+            (
+                Message::Unknown {
+                    msg_type: 99,
+                    payload: vec![],
+                },
+                "unknown",
+                MessageType(99),
+            ),
+        ];
+        for (msg, name, ty) in cases {
+            assert_eq!(msg.msg_type(), ty, "wrong type number for {name}");
+            assert_eq!(msg.msg_name(), name, "wrong type name for {ty}");
+            assert_eq!(msg.to_string(), format!("{name}({})", ty.as_u16()));
+            assert_eq!(msg.to_string(), ty.to_string());
+        }
     }
 
     #[test]


### PR DESCRIPTION
I found this quite useful. This changes the logs like this:

```diff
-SendMessage: Some(258), 138 bytes 
+SendMessage: channel_update(258), 138 bytes
```

and

```diff
-expected 33, got 17
+expected accept_channel(33), got error(17)
```

WDYT? Concept ACK?