### PR TITLE
smite-ir: split determinism out of `has_side_effects`

### DIFF
--- a/smite-ir/src/minimizers/cse.rs
+++ b/smite-ir/src/minimizers/cse.rs
@@ -30,7 +30,7 @@ impl Minimizer for CommonSubexpressionEliminator {
             for input in &mut instr.inputs {
                 *input = new_idx[*input];
             }
-            if instr.operation.has_side_effects() {
+            if !instr.operation.is_pure() {
                 new_idx[i] = instructions.len();
                 instructions.push(instr);
                 continue;

--- a/smite-ir/src/mutators/instruction_reorder.rs
+++ b/smite-ir/src/mutators/instruction_reorder.rs
@@ -6,7 +6,9 @@ use super::Mutator;
 use crate::Program;
 
 /// Swaps two `Act` instructions that have no data dependencies between them.
-/// This explores alternative execution orderings while preserving SSA invariants.
+/// An `Act` is any instruction that is not pure, i.e. one whose position in the
+/// program affects behavior. This explores alternative execution orderings
+/// while preserving SSA invariants.
 pub struct InstructionReorderMutator;
 
 impl Mutator for InstructionReorderMutator {
@@ -16,7 +18,7 @@ impl Mutator for InstructionReorderMutator {
             .instructions
             .iter()
             .enumerate()
-            .filter_map(|(i, instr)| instr.operation.has_side_effects().then_some(i))
+            .filter_map(|(i, instr)| (!instr.operation.is_pure()).then_some(i))
             .choose(rng)
         else {
             return false;
@@ -37,7 +39,7 @@ impl Mutator for InstructionReorderMutator {
             .filter(|&i| {
                 // Ensure the candidate is an Act and does not depend on anything
                 // defined at or after Act_1, guaranteeing it can be safely moved up.
-                program.instructions[i].operation.has_side_effects()
+                !program.instructions[i].operation.is_pure()
                     && !program.instructions[i]
                         .inputs
                         .iter()

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -233,6 +233,7 @@ pub enum Operation {
     /// Sign wallet inputs of the transaction and broadcast it via `bitcoin-cli`.
     /// Input: `FundingTransaction`.
     BroadcastTransaction,
+    // -- Query: read state from outside the program --
     /// Look up the confirmed block position of a broadcast funding transaction
     /// and produce the corresponding BOLT 7 `short_channel_id`.
     ///
@@ -688,7 +689,6 @@ impl fmt::Display for Operation {
             Self::LoadChannelType(v) => write!(f, "LoadChannelType({v})"),
             Self::LoadTargetPubkeyFromContext => write!(f, "LoadTargetPubkeyFromContext()"),
             Self::LoadChainHashFromContext => write!(f, "LoadChainHashFromContext()"),
-            Self::MineBlocks(v) => write!(f, "MineBlocks({v})"),
             // Operations with inputs: parens added by Program::Display.
             Self::DerivePoint => write!(f, "DerivePoint"),
             Self::ExtractAcceptChannel(field) => write!(f, "Extract{field}"),
@@ -713,6 +713,7 @@ impl fmt::Display for Operation {
             Self::RecvAcceptChannel => write!(f, "RecvAcceptChannel"),
             Self::RecvFundingSigned => write!(f, "RecvFundingSigned"),
             Self::RecvChannelReady => write!(f, "RecvChannelReady()"),
+            Self::MineBlocks(v) => write!(f, "MineBlocks({v})"),
             Self::BroadcastTransaction => write!(f, "BroadcastTransaction"),
             Self::LookupShortChannelId => write!(f, "LookupShortChannelId"),
         }
@@ -792,28 +793,6 @@ impl Operation {
                 VariableType::Amount,       // funding_satoshis
                 VariableType::FeeratePerKw, // feerate_per_kw
             ],
-            Self::SendMessage => vec![VariableType::Message],
-            Self::SendOpenChannel => vec![VariableType::OpenChannelMessage],
-            Self::SendFundingCreated => vec![
-                VariableType::FundingTransaction, // funding_transaction
-                VariableType::PrivateKey,         // opener_funding_privkey
-                VariableType::ChannelId,          // temporary_channel_id
-            ],
-            Self::SendChannelReady { .. } => vec![
-                VariableType::ChannelId,      // channel_id
-                VariableType::Point,          // second_per_commitment_point
-                VariableType::ShortChannelId, // short_channel_id (alias)
-            ],
-            Self::SendShutdown => vec![
-                VariableType::ChannelId, // channel_id
-                VariableType::Bytes,     // scriptpubkey
-            ],
-            Self::RecvAcceptChannel => vec![VariableType::SentOpenChannel],
-            Self::RecvFundingSigned => vec![VariableType::SentFundingCreated],
-            Self::BroadcastTransaction | Self::LookupShortChannelId => {
-                vec![VariableType::FundingTransaction]
-            }
-
             Self::BuildOpenChannel => vec![
                 VariableType::ChainHash,    // chain_hash
                 VariableType::ChannelId,    // temporary_channel_id
@@ -878,6 +857,27 @@ impl Operation {
                 VariableType::PrivateKey,     // bitcoin_sk_1 (our bitcoin signing key)
                 VariableType::Point,          // bitcoin_key_2 (target's bitcoin public key)
             ],
+            Self::SendMessage => vec![VariableType::Message],
+            Self::SendOpenChannel => vec![VariableType::OpenChannelMessage],
+            Self::SendFundingCreated => vec![
+                VariableType::FundingTransaction, // funding_transaction
+                VariableType::PrivateKey,         // opener_funding_privkey
+                VariableType::ChannelId,          // temporary_channel_id
+            ],
+            Self::SendChannelReady { .. } => vec![
+                VariableType::ChannelId,      // channel_id
+                VariableType::Point,          // second_per_commitment_point
+                VariableType::ShortChannelId, // short_channel_id (alias)
+            ],
+            Self::SendShutdown => vec![
+                VariableType::ChannelId, // channel_id
+                VariableType::Bytes,     // scriptpubkey
+            ],
+            Self::RecvAcceptChannel => vec![VariableType::SentOpenChannel],
+            Self::RecvFundingSigned => vec![VariableType::SentFundingCreated],
+            Self::BroadcastTransaction | Self::LookupShortChannelId => {
+                vec![VariableType::FundingTransaction]
+            }
         }
     }
 
@@ -932,29 +932,16 @@ impl Operation {
     }
 
     /// Returns `true` if this operation has I/O side effects and therefore
-    /// cannot be dropped by DCE or deduplicated by CSE.
+    /// cannot be dropped by DCE.
     #[must_use]
     pub fn has_side_effects(&self) -> bool {
         match self {
-            Self::SendMessage
-            | Self::SendOpenChannel
-            | Self::SendFundingCreated
-            | Self::SendChannelReady { .. }
-            | Self::SendShutdown
-            | Self::RecvAcceptChannel
-            | Self::RecvFundingSigned
-            | Self::RecvChannelReady
-            | Self::MineBlocks(_)
-            | Self::CreateFundingTransaction
-            | Self::BroadcastTransaction
-            | Self::LookupShortChannelId => true,
             Self::LoadAmount(_)
             | Self::LoadShortChannelId(_)
-            | Self::BuildChannelAnnouncement
             | Self::LoadFeeratePerKw(_)
-            | Self::LoadForwardingFee(_)
             | Self::LoadBlockHeight(_)
             | Self::LoadTimestamp(_)
+            | Self::LoadForwardingFee(_)
             | Self::LoadU16(_)
             | Self::LoadU8(_)
             | Self::LoadBytes(_)
@@ -968,10 +955,86 @@ impl Operation {
             | Self::DerivePoint
             | Self::ExtractAcceptChannel(_)
             | Self::BuildOpenChannel
+            | Self::BuildChannelAnnouncement
             | Self::BuildNodeAnnouncement { .. }
             | Self::BuildChannelUpdate
-            | Self::BuildAnnouncementSignatures => false,
+            | Self::BuildAnnouncementSignatures
+            | Self::LookupShortChannelId => false,
+            Self::CreateFundingTransaction
+            | Self::SendMessage
+            | Self::SendOpenChannel
+            | Self::SendFundingCreated
+            | Self::SendChannelReady { .. }
+            | Self::SendShutdown
+            | Self::RecvAcceptChannel
+            | Self::RecvFundingSigned
+            | Self::RecvChannelReady
+            | Self::MineBlocks(_)
+            | Self::BroadcastTransaction => true,
         }
+    }
+
+    /// Returns `true` if this operation's result depends only on its inputs.
+    /// An operation that also reads external state cannot be deduplicated by
+    /// CSE even when it is free of side effects, and its position in the
+    /// program is meaningful.
+    #[must_use]
+    pub fn depends_only_on_inputs(&self) -> bool {
+        match self {
+            // The program context is recorded before the Nyx snapshot and does
+            // not change during execution, so the context loads behave like
+            // the literal loads above.
+            Self::LoadAmount(_)
+            | Self::LoadShortChannelId(_)
+            | Self::LoadFeeratePerKw(_)
+            | Self::LoadBlockHeight(_)
+            | Self::LoadTimestamp(_)
+            | Self::LoadForwardingFee(_)
+            | Self::LoadU16(_)
+            | Self::LoadU8(_)
+            | Self::LoadBytes(_)
+            | Self::LoadFeatures(_)
+            | Self::LoadPrivateKey(_)
+            | Self::LoadChannelId(_)
+            | Self::LoadShutdownScript(_)
+            | Self::LoadChannelType(_)
+            | Self::LoadTargetPubkeyFromContext
+            | Self::LoadChainHashFromContext
+            | Self::DerivePoint
+            | Self::ExtractAcceptChannel(_)
+            | Self::BuildOpenChannel
+            | Self::BuildChannelAnnouncement
+            | Self::BuildNodeAnnouncement { .. }
+            | Self::BuildChannelUpdate
+            | Self::BuildAnnouncementSignatures
+            | Self::SendMessage
+            | Self::SendOpenChannel
+            | Self::SendChannelReady { .. }
+            | Self::SendShutdown => true,
+            // `CreateFundingTransaction` selects coins from the wallet, whose
+            // contents change as transactions are created and broadcast.
+            // `SendFundingCreated` builds its message from the recorded
+            // negotiation and channel state. The `Recv` operations read
+            // whatever the target sends us. `MineBlocks` also mines whatever
+            // the private mempool holds, `BroadcastTransaction` dedups against
+            // it, and `LookupShortChannelId` reads chain state.
+            Self::CreateFundingTransaction
+            | Self::SendFundingCreated
+            | Self::RecvAcceptChannel
+            | Self::RecvFundingSigned
+            | Self::RecvChannelReady
+            | Self::MineBlocks(_)
+            | Self::BroadcastTransaction
+            | Self::LookupShortChannelId => false,
+        }
+    }
+
+    /// Returns `true` if this operation is free of side effects and depends
+    /// only on its inputs. Only pure operations may be merged by CSE or
+    /// reordered freely.
+    #[must_use]
+    pub fn is_pure(&self) -> bool {
+        !self.has_side_effects() && self.depends_only_on_inputs()
     }
 
     /// Returns true if this operation has parameters that can be mutated

--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -233,6 +233,7 @@ pub enum Operation {
     /// Sign wallet inputs of the transaction and broadcast it via `bitcoin-cli`.
     /// Input: `FundingTransaction`.
     BroadcastTransaction,
+    // -- Query: read state from outside the program --
     /// Look up the confirmed block position of a broadcast funding transaction
     /// and produce the corresponding BOLT 7 `short_channel_id`.
     ///
@@ -688,7 +689,6 @@ impl fmt::Display for Operation {
             Self::LoadChannelType(v) => write!(f, "LoadChannelType({v})"),
             Self::LoadTargetPubkeyFromContext => write!(f, "LoadTargetPubkeyFromContext()"),
             Self::LoadChainHashFromContext => write!(f, "LoadChainHashFromContext()"),
-            Self::MineBlocks(v) => write!(f, "MineBlocks({v})"),
             // Operations with inputs: parens added by Program::Display.
             Self::DerivePoint => write!(f, "DerivePoint"),
             Self::ExtractAcceptChannel(field) => write!(f, "Extract{field}"),
@@ -713,6 +713,7 @@ impl fmt::Display for Operation {
             Self::RecvAcceptChannel => write!(f, "RecvAcceptChannel"),
             Self::RecvFundingSigned => write!(f, "RecvFundingSigned"),
             Self::RecvChannelReady => write!(f, "RecvChannelReady()"),
+            Self::MineBlocks(v) => write!(f, "MineBlocks({v})"),
             Self::BroadcastTransaction => write!(f, "BroadcastTransaction"),
             Self::LookupShortChannelId => write!(f, "LookupShortChannelId"),
         }
@@ -792,28 +793,6 @@ impl Operation {
                 VariableType::Amount,       // funding_satoshis
                 VariableType::FeeratePerKw, // feerate_per_kw
             ],
-            Self::SendMessage => vec![VariableType::Message],
-            Self::SendOpenChannel => vec![VariableType::OpenChannelMessage],
-            Self::SendFundingCreated => vec![
-                VariableType::FundingTransaction, // funding_transaction
-                VariableType::PrivateKey,         // opener_funding_privkey
-                VariableType::ChannelId,          // temporary_channel_id
-            ],
-            Self::SendChannelReady { .. } => vec![
-                VariableType::ChannelId,      // channel_id
-                VariableType::Point,          // second_per_commitment_point
-                VariableType::ShortChannelId, // short_channel_id (alias)
-            ],
-            Self::SendShutdown => vec![
-                VariableType::ChannelId, // channel_id
-                VariableType::Bytes,     // scriptpubkey
-            ],
-            Self::RecvAcceptChannel => vec![VariableType::SentOpenChannel],
-            Self::RecvFundingSigned => vec![VariableType::SentFundingCreated],
-            Self::BroadcastTransaction | Self::LookupShortChannelId => {
-                vec![VariableType::FundingTransaction]
-            }
-
             Self::BuildOpenChannel => vec![
                 VariableType::ChainHash,    // chain_hash
                 VariableType::ChannelId,    // temporary_channel_id
@@ -878,6 +857,27 @@ impl Operation {
                 VariableType::PrivateKey,     // bitcoin_sk_1 (our bitcoin signing key)
                 VariableType::Point,          // bitcoin_key_2 (target's bitcoin public key)
             ],
+            Self::SendMessage => vec![VariableType::Message],
+            Self::SendOpenChannel => vec![VariableType::OpenChannelMessage],
+            Self::SendFundingCreated => vec![
+                VariableType::FundingTransaction, // funding_transaction
+                VariableType::PrivateKey,         // opener_funding_privkey
+                VariableType::ChannelId,          // temporary_channel_id
+            ],
+            Self::SendChannelReady { .. } => vec![
+                VariableType::ChannelId,      // channel_id
+                VariableType::Point,          // second_per_commitment_point
+                VariableType::ShortChannelId, // short_channel_id (alias)
+            ],
+            Self::SendShutdown => vec![
+                VariableType::ChannelId, // channel_id
+                VariableType::Bytes,     // scriptpubkey
+            ],
+            Self::RecvAcceptChannel => vec![VariableType::SentOpenChannel],
+            Self::RecvFundingSigned => vec![VariableType::SentFundingCreated],
+            Self::BroadcastTransaction | Self::LookupShortChannelId => {
+                vec![VariableType::FundingTransaction]
+            }
         }
     }
 
@@ -932,29 +932,16 @@ impl Operation {
     }
 
     /// Returns `true` if this operation has I/O side effects and therefore
-    /// cannot be dropped by DCE or deduplicated by CSE.
+    /// cannot be dropped by DCE.
     #[must_use]
     pub fn has_side_effects(&self) -> bool {
         match self {
-            Self::SendMessage
-            | Self::SendOpenChannel
-            | Self::SendFundingCreated
-            | Self::SendChannelReady { .. }
-            | Self::SendShutdown
-            | Self::RecvAcceptChannel
-            | Self::RecvFundingSigned
-            | Self::RecvChannelReady
-            | Self::MineBlocks(_)
-            | Self::CreateFundingTransaction
-            | Self::BroadcastTransaction
-            | Self::LookupShortChannelId => true,
             Self::LoadAmount(_)
             | Self::LoadShortChannelId(_)
-            | Self::BuildChannelAnnouncement
             | Self::LoadFeeratePerKw(_)
-            | Self::LoadForwardingFee(_)
             | Self::LoadBlockHeight(_)
             | Self::LoadTimestamp(_)
+            | Self::LoadForwardingFee(_)
             | Self::LoadU16(_)
             | Self::LoadU8(_)
             | Self::LoadBytes(_)
@@ -968,10 +955,85 @@ impl Operation {
             | Self::DerivePoint
             | Self::ExtractAcceptChannel(_)
             | Self::BuildOpenChannel
+            | Self::BuildChannelAnnouncement
             | Self::BuildNodeAnnouncement { .. }
             | Self::BuildChannelUpdate
-            | Self::BuildAnnouncementSignatures => false,
+            | Self::BuildAnnouncementSignatures
+            | Self::LookupShortChannelId => false,
+            Self::CreateFundingTransaction
+            | Self::SendMessage
+            | Self::SendOpenChannel
+            | Self::SendFundingCreated
+            | Self::SendChannelReady { .. }
+            | Self::SendShutdown
+            | Self::RecvAcceptChannel
+            | Self::RecvFundingSigned
+            | Self::RecvChannelReady
+            | Self::MineBlocks(_)
+            | Self::BroadcastTransaction => true,
         }
+    }
+
+    /// Returns `true` if this operation's result depends only on its inputs.
+    /// An operation that also reads external state cannot be deduplicated by
+    /// CSE even when it is free of side effects, and its position in the
+    /// program is meaningful.
+    #[must_use]
+    pub fn depends_only_on_inputs(&self) -> bool {
+        match self {
+            // The program context is recorded before the Nyx snapshot and does
+            // not change during execution, so the context loads behave like
+            // the literal loads above.
+            Self::LoadAmount(_)
+            | Self::LoadShortChannelId(_)
+            | Self::LoadFeeratePerKw(_)
+            | Self::LoadBlockHeight(_)
+            | Self::LoadTimestamp(_)
+            | Self::LoadForwardingFee(_)
+            | Self::LoadU16(_)
+            | Self::LoadU8(_)
+            | Self::LoadBytes(_)
+            | Self::LoadFeatures(_)
+            | Self::LoadPrivateKey(_)
+            | Self::LoadChannelId(_)
+            | Self::LoadShutdownScript(_)
+            | Self::LoadChannelType(_)
+            | Self::LoadTargetPubkeyFromContext
+            | Self::LoadChainHashFromContext
+            | Self::DerivePoint
+            | Self::ExtractAcceptChannel(_)
+            | Self::BuildOpenChannel
+            | Self::BuildChannelAnnouncement
+            | Self::BuildNodeAnnouncement { .. }
+            | Self::BuildChannelUpdate
+            | Self::BuildAnnouncementSignatures
+            | Self::SendMessage
+            | Self::SendOpenChannel
+            | Self::SendChannelReady { .. }
+            | Self::SendShutdown
+            | Self::MineBlocks(_)
+            | Self::BroadcastTransaction => true,
+            // `CreateFundingTransaction` selects coins from the wallet, whose
+            // contents change as transactions are created and broadcast.
+            // `SendFundingCreated` builds its message from the recorded
+            // negotiation and channel state. The `Recv` operations read
+            // whatever the target sends us, and `LookupShortChannelId` reads
+            // chain state.
+            Self::CreateFundingTransaction
+            | Self::SendFundingCreated
+            | Self::RecvAcceptChannel
+            | Self::RecvFundingSigned
+            | Self::RecvChannelReady
+            | Self::LookupShortChannelId => false,
+        }
+    }
+
+    /// Returns `true` if this operation is free of side effects and depends
+    /// only on its inputs. Only pure operations may be merged by CSE or
+    /// reordered freely.
+    #[must_use]
+    pub fn is_pure(&self) -> bool {
+        !self.has_side_effects() && self.depends_only_on_inputs()
     }
 
     /// Returns true if this operation has parameters that can be mutated

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -709,9 +709,12 @@ fn lookup_short_channel_id_operation() {
     assert_eq!(op.input_types(), vec![VariableType::FundingTransaction]);
     assert_eq!(op.output_type(), Some(VariableType::ShortChannelId));
     assert!(!op.is_param_mutable());
-    // Non-deterministic (depends on chain state), so must not be dropped by DCE
-    // or deduplicated by CSE.
-    assert!(op.has_side_effects());
+    // Read-only, so DCE may drop it when its result is unused.
+    assert!(!op.has_side_effects());
+    // Depends on chain state, so it must not be deduplicated by CSE and its
+    // position relative to `MineBlocks` is meaningful.
+    assert!(!op.depends_only_on_inputs());
+    assert!(!op.is_pure());
     assert_eq!(op.to_string(), "LookupShortChannelId");
 }
 
@@ -750,6 +753,15 @@ fn create_and_broadcast_tx_instructions() -> Vec<Instruction> {
             inputs: vec![6],
         },
     ]
+}
+
+/// Returns the index of the funding transaction produced by
+/// `create_and_broadcast_tx_instructions`.
+fn funding_tx_index(instrs: &[Instruction]) -> usize {
+    instrs
+        .iter()
+        .position(|i| matches!(i.operation, Operation::CreateFundingTransaction))
+        .expect("the helper creates a funding transaction")
 }
 
 #[test]
@@ -2409,6 +2421,48 @@ fn instr_reorder_preserves_well_formedness() {
     assert_mutator_preserves_well_formedness(&InstructionReorderMutator, &original);
 }
 
+// `LookupShortChannelId` is read-only but depends on chain state beyond
+// its inputs, so it's still useful for mutators to be able to move it.
+#[test]
+fn instr_reorder_moves_lookup_short_channel_id() {
+    let mut instrs = create_and_broadcast_tx_instructions();
+    let funding_tx = funding_tx_index(&instrs);
+    instrs.push(Instruction {
+        operation: Operation::MineBlocks(6),
+        inputs: vec![],
+    });
+    let mine_idx = instrs.len() - 1;
+    instrs.push(Instruction {
+        operation: Operation::LookupShortChannelId,
+        inputs: vec![funding_tx],
+    });
+
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut moved = false;
+    for _ in 0..100 {
+        let mut program = Program {
+            instructions: instrs.clone(),
+        };
+        if !InstructionReorderMutator.mutate(&mut program, &mut rng) {
+            continue;
+        }
+        assert_well_formed(&program);
+        let lookup = program
+            .instructions
+            .iter()
+            .position(|i| matches!(i.operation, Operation::LookupShortChannelId))
+            .expect("lookup is never removed by a reorder");
+        if lookup <= mine_idx {
+            moved = true;
+            break;
+        }
+    }
+    assert!(
+        moved,
+        "reorder must be able to move the lookup before MineBlocks"
+    );
+}
+
 // -- GeneratorInsertionMutator tests --
 
 // A test generator that doesn't use RNG, ensuring its operations are always predictable.
@@ -2736,6 +2790,79 @@ fn dead_code_idempotent() {
     assert_eq!(once, twice, "elimination is idempotent");
 }
 
+// `LookupShortChannelId` is read-only, so a lookup whose result nothing
+// consumes can be dropped.
+#[test]
+fn dead_code_drops_unused_lookup_short_channel_id() {
+    let mut instrs = create_and_broadcast_tx_instructions();
+    let funding_tx = funding_tx_index(&instrs);
+    instrs.push(Instruction {
+        operation: Operation::MineBlocks(6),
+        inputs: vec![],
+    });
+    instrs.push(Instruction {
+        operation: Operation::LookupShortChannelId,
+        inputs: vec![funding_tx],
+    });
+    let mut program = Program {
+        instructions: instrs,
+    };
+
+    assert!(DeadCodeEliminator.minimize(&mut program));
+    assert!(
+        !program
+            .instructions
+            .iter()
+            .any(|i| matches!(i.operation, Operation::LookupShortChannelId)),
+        "DCE must drop a LookupShortChannelId whose result is unused",
+    );
+    assert_well_formed(&program);
+}
+
+// A lookup whose result is consumed must not be removed.
+#[test]
+fn dead_code_keeps_referenced_lookup_short_channel_id() {
+    let mut instrs = create_and_broadcast_tx_instructions();
+    let funding_tx = funding_tx_index(&instrs);
+    let point = instrs
+        .iter()
+        .position(|i| matches!(i.operation, Operation::DerivePoint))
+        .expect("the helper derives a point");
+    instrs.push(Instruction {
+        operation: Operation::MineBlocks(6),
+        inputs: vec![],
+    });
+    instrs.push(Instruction {
+        operation: Operation::LookupShortChannelId,
+        inputs: vec![funding_tx],
+    });
+    let scid = instrs.len() - 1;
+    instrs.push(Instruction {
+        operation: Operation::LoadChannelId([1u8; 32]),
+        inputs: vec![],
+    });
+    let channel_id = instrs.len() - 1;
+    instrs.push(Instruction {
+        operation: Operation::SendChannelReady {
+            include_alias: true,
+        },
+        inputs: vec![channel_id, point, scid],
+    });
+    let mut program = Program {
+        instructions: instrs,
+    };
+
+    DeadCodeEliminator.minimize(&mut program);
+    assert!(
+        program
+            .instructions
+            .iter()
+            .any(|i| matches!(i.operation, Operation::LookupShortChannelId)),
+        "DeadCodeEliminator must not remove a referenced LookupShortChannelId",
+    );
+    assert_well_formed(&program);
+}
+
 // -- CommonSubexpressionEliminator tests --
 
 #[test]
@@ -2782,6 +2909,42 @@ fn cse_rewires_references() {
     };
     assert!(CommonSubexpressionEliminator.minimize(&mut program));
     assert_eq!(program, expected);
+    assert_well_formed(&program);
+}
+
+// Two lookups of the same funding transaction can return different results
+// when a `MineBlocks` separates them, so CSE must not merge them even though
+// `LookupShortChannelId` has no side effects.
+#[test]
+fn cse_does_not_merge_lookup_short_channel_id() {
+    let mut instrs = create_and_broadcast_tx_instructions();
+    let funding_tx = funding_tx_index(&instrs);
+    instrs.push(Instruction {
+        operation: Operation::LookupShortChannelId,
+        inputs: vec![funding_tx],
+    });
+    instrs.push(Instruction {
+        operation: Operation::MineBlocks(6),
+        inputs: vec![],
+    });
+    instrs.push(Instruction {
+        operation: Operation::LookupShortChannelId,
+        inputs: vec![funding_tx],
+    });
+    let mut program = Program {
+        instructions: instrs,
+    };
+
+    CommonSubexpressionEliminator.minimize(&mut program);
+    assert_eq!(
+        program
+            .instructions
+            .iter()
+            .filter(|i| matches!(i.operation, Operation::LookupShortChannelId))
+            .count(),
+        2,
+        "CSE must not merge lookups separated by MineBlocks",
+    );
     assert_well_formed(&program);
 }
 

--- a/smite-ir/src/tests.rs
+++ b/smite-ir/src/tests.rs
@@ -709,9 +709,12 @@ fn lookup_short_channel_id_operation() {
     assert_eq!(op.input_types(), vec![VariableType::FundingTransaction]);
     assert_eq!(op.output_type(), Some(VariableType::ShortChannelId));
     assert!(!op.is_param_mutable());
-    // Non-deterministic (depends on chain state), so must not be dropped by DCE
-    // or deduplicated by CSE.
-    assert!(op.has_side_effects());
+    // Read-only, so DCE may drop it when its result is unused.
+    assert!(!op.has_side_effects());
+    // Depends on chain state, so it must not be deduplicated by CSE and its
+    // position relative to `MineBlocks` is meaningful.
+    assert!(!op.depends_only_on_inputs());
+    assert!(!op.is_pure());
     assert_eq!(op.to_string(), "LookupShortChannelId");
 }
 
@@ -750,6 +753,15 @@ fn create_and_broadcast_tx_instructions() -> Vec<Instruction> {
             inputs: vec![6],
         },
     ]
+}
+
+/// Returns the index of the funding transaction produced by
+/// `create_and_broadcast_tx_instructions`.
+fn funding_tx_index(instrs: &[Instruction]) -> usize {
+    instrs
+        .iter()
+        .position(|i| matches!(i.operation, Operation::CreateFundingTransaction))
+        .expect("the helper creates a funding transaction")
 }
 
 #[test]
@@ -2409,6 +2421,49 @@ fn instr_reorder_preserves_well_formedness() {
     assert_mutator_preserves_well_formedness(&InstructionReorderMutator, &original);
 }
 
+// `LookupShortChannelId` is read-only but nondeterministic, so it stays an
+// `Act` and the mutator may still move it across a `MineBlocks`. That swap is
+// how a confirmed scid becomes the unconfirmed sentinel.
+#[test]
+fn instr_reorder_moves_lookup_short_channel_id() {
+    let mut instrs = create_and_broadcast_tx_instructions();
+    let funding_tx = funding_tx_index(&instrs);
+    instrs.push(Instruction {
+        operation: Operation::MineBlocks(6),
+        inputs: vec![],
+    });
+    let mine_idx = instrs.len() - 1;
+    instrs.push(Instruction {
+        operation: Operation::LookupShortChannelId,
+        inputs: vec![funding_tx],
+    });
+
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut moved = false;
+    for _ in 0..100 {
+        let mut program = Program {
+            instructions: instrs.clone(),
+        };
+        if !InstructionReorderMutator.mutate(&mut program, &mut rng) {
+            continue;
+        }
+        assert_well_formed(&program);
+        let lookup = program
+            .instructions
+            .iter()
+            .position(|i| matches!(i.operation, Operation::LookupShortChannelId))
+            .expect("lookup is never removed by a reorder");
+        if lookup <= mine_idx {
+            moved = true;
+            break;
+        }
+    }
+    assert!(
+        moved,
+        "reorder must be able to move the lookup before MineBlocks"
+    );
+}
+
 // -- GeneratorInsertionMutator tests --
 
 // A test generator that doesn't use RNG, ensuring its operations are always predictable.
@@ -2736,6 +2791,80 @@ fn dead_code_idempotent() {
     assert_eq!(once, twice, "elimination is idempotent");
 }
 
+// `LookupShortChannelId` is read-only, so a lookup whose result nothing
+// consumes can be dropped.
+#[test]
+fn dce_drops_unused_lookup_short_channel_id() {
+    let mut instrs = create_and_broadcast_tx_instructions();
+    let funding_tx = funding_tx_index(&instrs);
+    instrs.push(Instruction {
+        operation: Operation::MineBlocks(6),
+        inputs: vec![],
+    });
+    instrs.push(Instruction {
+        operation: Operation::LookupShortChannelId,
+        inputs: vec![funding_tx],
+    });
+    let mut program = Program {
+        instructions: instrs,
+    };
+
+    assert!(DeadCodeEliminator.minimize(&mut program));
+    assert!(
+        !program
+            .instructions
+            .iter()
+            .any(|i| matches!(i.operation, Operation::LookupShortChannelId)),
+        "DCE must drop a LookupShortChannelId whose result is unused",
+    );
+    assert_well_formed(&program);
+}
+
+// A lookup whose result is consumed must survive, now that it no longer
+// relies on being marked as side-effecting to stay in the program.
+#[test]
+fn dead_code_keeps_referenced_lookup_short_channel_id() {
+    let mut instrs = create_and_broadcast_tx_instructions();
+    let funding_tx = funding_tx_index(&instrs);
+    let point = instrs
+        .iter()
+        .position(|i| matches!(i.operation, Operation::DerivePoint))
+        .expect("the helper derives a point");
+    instrs.push(Instruction {
+        operation: Operation::MineBlocks(6),
+        inputs: vec![],
+    });
+    instrs.push(Instruction {
+        operation: Operation::LookupShortChannelId,
+        inputs: vec![funding_tx],
+    });
+    let scid = instrs.len() - 1;
+    instrs.push(Instruction {
+        operation: Operation::LoadChannelId([1u8; 32]),
+        inputs: vec![],
+    });
+    let channel_id = instrs.len() - 1;
+    instrs.push(Instruction {
+        operation: Operation::SendChannelReady {
+            include_alias: false,
+        },
+        inputs: vec![channel_id, point, scid],
+    });
+    let mut program = Program {
+        instructions: instrs,
+    };
+
+    DeadCodeEliminator.minimize(&mut program);
+    assert!(
+        program
+            .instructions
+            .iter()
+            .any(|i| matches!(i.operation, Operation::LookupShortChannelId)),
+        "DeadCodeEliminator must not remove a referenced LookupShortChannelId",
+    );
+    assert_well_formed(&program);
+}
+
 // -- CommonSubexpressionEliminator tests --
 
 #[test]
@@ -2782,6 +2911,42 @@ fn cse_rewires_references() {
     };
     assert!(CommonSubexpressionEliminator.minimize(&mut program));
     assert_eq!(program, expected);
+    assert_well_formed(&program);
+}
+
+// Two lookups of the same funding transaction can return different results
+// when a `MineBlocks` separates them, so CSE must not merge them even though
+// `LookupShortChannelId` has no side effects.
+#[test]
+fn cse_does_not_merge_lookup_short_channel_id() {
+    let mut instrs = create_and_broadcast_tx_instructions();
+    let funding_tx = funding_tx_index(&instrs);
+    instrs.push(Instruction {
+        operation: Operation::LookupShortChannelId,
+        inputs: vec![funding_tx],
+    });
+    instrs.push(Instruction {
+        operation: Operation::MineBlocks(6),
+        inputs: vec![],
+    });
+    instrs.push(Instruction {
+        operation: Operation::LookupShortChannelId,
+        inputs: vec![funding_tx],
+    });
+    let mut program = Program {
+        instructions: instrs,
+    };
+
+    CommonSubexpressionEliminator.minimize(&mut program);
+    assert_eq!(
+        program
+            .instructions
+            .iter()
+            .filter(|i| matches!(i.operation, Operation::LookupShortChannelId))
+            .count(),
+        2,
+        "CSE must not merge lookups separated by MineBlocks",
+    );
     assert_well_formed(&program);
 }
 


### PR DESCRIPTION
Follow-up to #155, where we agreed `LookupShortChannelId` doesn't really have side effects and that CSE wants a separate question answered.

`has_side_effects` was being asked three different questions by three callers: DCE wants to know whether an instruction can be dropped, CSE wants to know whether two instructions can be merged, and `InstructionReorderMutator` wants to know whether an instruction's position matters.  Those coincide for every operation we had until `LookupShortChannelId`, which is read-only but reads chain state, so it was marked as side-effecting to keep CSE away from it.

Add `depends_only_on_inputs`, and `is_pure` on top of it, so each caller asks what it actually means.  DCE keeps using `has_side_effects`, while CSE and the reorder mutator switch to `is_pure`.  `LookupShortChannelId` becomes side-effect free, and it joins `CreateFundingTransaction`, `SendFundingCreated`, and the `Recv` operations in reading state beyond its inputs.

The only behavior change is that DCE can now drop a `LookupShortChannelId` whose result nothing consumes.  I checked every operation, and it is the only one where `!is_pure()` differs from `has_side_effects()`, so CSE's skip set and the reorder mutator's candidate set are unchanged.

Keeping the lookup reorderable matters: moving it across a `MineBlocks` is what turns a confirmed `short_channel_id` into the unconfirmed sentinel, and it's the only way to reach the sentinel in a program whose scid comes from a lookup.  Marking it pure would have silently removed that, so there's a test covering it along with tests for the CSE and DCE behavior.

Ref: #155
