### PR TITLE
fix: use tmpfs for Docker execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ When AFL++ finds a crash:
 cp /tmp/smite-out/default/crashes/<crashing-input> ./crash
 
 # Reproduce in local mode (use the matching image and scenario binary)
-docker run --rm -v $PWD/crash:/input.bin -e SMITE_INPUT=/input.bin smite-$TARGET-$SCENARIO /$TARGET-scenario
+docker run --rm --tmpfs /tmp:rw,exec,size=1g -v $PWD/crash:/input.bin -e SMITE_INPUT=/input.bin smite-$TARGET-$SCENARIO /$TARGET-scenario
 ```
+
+The `--tmpfs /tmp:rw,exec,size=1g` option provides a temporary in-memory filesystem for `/tmp`, matching the `tmpfs` environment available inside the Nyx VM. This halves startup time.
 
 ### Coverage Report Mode
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ When AFL++ finds a crash:
 cp /tmp/smite-out/default/crashes/<crashing-input> ./crash
 
 # Reproduce in local mode (use the matching image and scenario binary)
-docker run --rm -v $PWD/crash:/input.bin -e SMITE_INPUT=/input.bin smite-$TARGET-$SCENARIO /$TARGET-scenario
+docker run --rm --tmpfs /tmp:rw,exec,size=1g -v $PWD/crash:/input.bin -e SMITE_INPUT=/input.bin smite-$TARGET-$SCENARIO /$TARGET-scenario
 ```
+
+The `--tmpfs /tmp:rw,exec,size=1g` option provides a temporary in-memory filesystem for `/tmp`, matching the `tmpfs` environment available inside the Nyx VM. This helps keep the local execution environment consistent with the one used during fuzzing.
 
 ### Coverage Report Mode
 

--- a/scripts/coverage-report.sh
+++ b/scripts/coverage-report.sh
@@ -5,7 +5,7 @@
 # Usage: ./scripts/coverage-report.sh <target> <scenario> <corpus-dir> [output-dir]
 #
 # Targets:   lnd, cln, ldk, eclair
-# Scenarios: encrypted_bytes, noise, init
+# Scenarios: encrypted_bytes, noise, ir, init
 #
 # This script:
 # 1. Builds (if needed) a coverage-instrumented Docker image
@@ -19,7 +19,7 @@ if [ $# -lt 3 ]; then
     echo ""
     echo "Arguments:"
     echo "  target      Target implementation (lnd, cln, ldk, eclair)"
-    echo "  scenario    Scenario name (encrypted_bytes, noise, init)"
+    echo "  scenario    Scenario name (encrypted_bytes, noise, ir, init)"
     echo "  corpus-dir  Directory containing fuzz input files"
     echo "  output-dir  Output directory (default: ./<target>-<scenario>-coverage-report)"
     echo ""
@@ -95,6 +95,13 @@ if docker info 2>/dev/null | grep -q "rootless"; then
     DOCKER_USER=()
 fi
 
+# Run /tmp from an in-memory filesystem, matching the Nyx VM, which runs
+# entirely from initramfs. Avoiding disk I/O roughly halves target startup
+# time. exec is required because Eclair's JVM writes executable files (native
+# libraries extracted from JARs) into /tmp and cannot run them from a noexec
+# mount.
+DOCKER_TMPFS=(--tmpfs /tmp:rw,exec,size=1g)
+
 # Build coverage image if needed (use REBUILD=1 to force rebuild)
 if [ "${REBUILD:-}" = "1" ] || ! docker image inspect "$DOCKER_IMAGE" >/dev/null 2>&1; then
     SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -134,7 +141,7 @@ run_input() {
         rm -rf "$covdir"
         mkdir "$covdir"
 
-        docker run --rm "${DOCKER_USER[@]}" \
+        docker run --rm "${DOCKER_USER[@]}" "${DOCKER_TMPFS[@]}" \
             -v "$CORPUS_DIR:/corpus:ro" \
             -v "$covdir:/covdata" \
             -e SMITE_INPUT="/corpus/$input_name" \
@@ -229,7 +236,7 @@ echo "Merging coverage data and generating report..."
 # tools, so the merge step is necessarily target-specific.
 case "$TARGET" in
     lnd)
-        docker run --rm "${DOCKER_USER[@]}" \
+        docker run --rm "${DOCKER_USER[@]}" "${DOCKER_TMPFS[@]}" \
             -v "$OUTPUT_DIR:/output" \
             -e GOCACHE=/tmp/go-cache \
             -e GOPATH=/tmp/go \
@@ -258,7 +265,7 @@ case "$TARGET" in
         ;;
 
     cln|ldk)
-        docker run --rm "${DOCKER_USER[@]}" \
+        docker run --rm "${DOCKER_USER[@]}" "${DOCKER_TMPFS[@]}" \
             -v "$OUTPUT_DIR:/output" \
             -e TARGET="$TARGET" \
             "$DOCKER_IMAGE" \
@@ -306,7 +313,7 @@ case "$TARGET" in
         ;;
 
     eclair)
-        docker run --rm "${DOCKER_USER[@]}" \
+        docker run --rm "${DOCKER_USER[@]}" "${DOCKER_TMPFS[@]}" \
             -v "$OUTPUT_DIR:/output" \
             "$DOCKER_IMAGE" \
             sh -c '

--- a/scripts/coverage-report.sh
+++ b/scripts/coverage-report.sh
@@ -5,7 +5,7 @@
 # Usage: ./scripts/coverage-report.sh <target> <scenario> <corpus-dir> [output-dir]
 #
 # Targets:   lnd, cln, ldk, eclair
-# Scenarios: encrypted_bytes, noise, init
+# Scenarios: encrypted_bytes, noise, ir, init
 #
 # This script:
 # 1. Builds (if needed) a coverage-instrumented Docker image
@@ -19,7 +19,7 @@ if [ $# -lt 3 ]; then
     echo ""
     echo "Arguments:"
     echo "  target      Target implementation (lnd, cln, ldk, eclair)"
-    echo "  scenario    Scenario name (encrypted_bytes, noise, init)"
+    echo "  scenario    Scenario name (encrypted_bytes, noise, ir, init)"
     echo "  corpus-dir  Directory containing fuzz input files"
     echo "  output-dir  Output directory (default: ./<target>-<scenario>-coverage-report)"
     echo ""
@@ -135,6 +135,7 @@ run_input() {
         mkdir "$covdir"
 
         docker run --rm "${DOCKER_USER[@]}" \
+            --tmpfs /tmp:rw,exec,size=1g \
             -v "$CORPUS_DIR:/corpus:ro" \
             -v "$covdir:/covdata" \
             -e SMITE_INPUT="/corpus/$input_name" \
@@ -230,6 +231,7 @@ echo "Merging coverage data and generating report..."
 case "$TARGET" in
     lnd)
         docker run --rm "${DOCKER_USER[@]}" \
+            --tmpfs /tmp:rw,exec,size=1g \
             -v "$OUTPUT_DIR:/output" \
             -e GOCACHE=/tmp/go-cache \
             -e GOPATH=/tmp/go \
@@ -259,6 +261,7 @@ case "$TARGET" in
 
     cln|ldk)
         docker run --rm "${DOCKER_USER[@]}" \
+            --tmpfs /tmp:rw,exec,size=1g \
             -v "$OUTPUT_DIR:/output" \
             -e TARGET="$TARGET" \
             "$DOCKER_IMAGE" \
@@ -307,6 +310,7 @@ case "$TARGET" in
 
     eclair)
         docker run --rm "${DOCKER_USER[@]}" \
+            --tmpfs /tmp:rw,exec,size=1g \
             -v "$OUTPUT_DIR:/output" \
             "$DOCKER_IMAGE" \
             sh -c '

--- a/scripts/symbolize-crash.sh
+++ b/scripts/symbolize-crash.sh
@@ -17,7 +17,7 @@ if [ $# -ne 2 ]; then
     echo "Usage: $0 <scenario> <crash-log>"
     echo ""
     echo "Arguments:"
-    echo "  scenario   Scenario name (encrypted_bytes, noise, init)"
+    echo "  scenario   Scenario name (encrypted_bytes, noise, ir, init)"
     echo "  crash-log  File containing unsymbolized crash report"
     exit 1
 fi
@@ -67,7 +67,11 @@ for binary in "${!BINARY_OFFSETS[@]}"; do
 
     # llvm-symbolizer outputs pairs of lines (function, file:line:col) for each
     # address, including inlined functions. Blank lines separate addresses.
-    result=$(docker run --rm "$BUILDER_IMAGE" \
+    #
+    # /tmp runs from an in-memory filesystem so symbolizer scratch data never
+    # hits the disk. exec is kept for consistency with the other scripts, where
+    # Eclair's JVM needs to run native libraries it extracts into /tmp.
+    result=$(docker run --rm --tmpfs /tmp:rw,exec,size=1g "$BUILDER_IMAGE" \
         llvm-symbolizer --obj="$binary" "${offsets[@]}" 2>/dev/null) || true
 
     # Parse output using blank lines as address boundaries.

--- a/scripts/symbolize-crash.sh
+++ b/scripts/symbolize-crash.sh
@@ -17,7 +17,7 @@ if [ $# -ne 2 ]; then
     echo "Usage: $0 <scenario> <crash-log>"
     echo ""
     echo "Arguments:"
-    echo "  scenario   Scenario name (encrypted_bytes, noise, init)"
+    echo "  scenario   Scenario name (encrypted_bytes, noise, ir, init)"
     echo "  crash-log  File containing unsymbolized crash report"
     exit 1
 fi
@@ -67,7 +67,7 @@ for binary in "${!BINARY_OFFSETS[@]}"; do
 
     # llvm-symbolizer outputs pairs of lines (function, file:line:col) for each
     # address, including inlined functions. Blank lines separate addresses.
-    result=$(docker run --rm "$BUILDER_IMAGE" \
+    result=$(docker run --rm --tmpfs /tmp:rw,exec,size=1g "$BUILDER_IMAGE" \
         llvm-symbolizer --obj="$binary" "${offsets[@]}" 2>/dev/null) || true
 
     # Parse output using blank lines as address boundaries.


### PR DESCRIPTION
Docker containers perform disk I/O by default, unlike the NYX VM, which runs from initramfs and is significantly faster. Use a tmpfs for /tmp in local execution, coverage reporting, and crash symbolization to better match the NYX environment.

Also document the tmpfs option and add the ir scenario to the script usage information.