### PR TITLE
bitcoind: check createwallet status

### DIFF
--- a/smite-scenarios/src/targets/bitcoind.rs
+++ b/smite-scenarios/src/targets/bitcoind.rs
@@ -133,13 +133,20 @@ pub fn start(
 /// Creates wallet and generates initial blocks.
 fn setup_wallet(cli: &BitcoinCli) -> Result<(), TargetError> {
     // Create wallet
-    let _ = cli
+    let status = cli
         .run()
         .arg("createwallet")
         .arg("default")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .status();
+        .status()?;
+
+    // command fails if wallet already exists (i.e. SMITE_DATA_DIR was mounted)
+    if !status.success() {
+        return Err(TargetError::StartFailed(
+            "failed to create wallet (does it already exist?)".into(),
+        ));
+    }
 
     // Generate initial blocks
     let status = cli


### PR DESCRIPTION
When I use `SMITE_DATA_DIR` to mount the bitcoin datadir, the wallet can already exist, and then `createwallet` fails.

With this PR, the error message will mention `failed to create wallet` instead of `failed to generate initial blocks`.