### PR TITLE
smite-scenarios: sync target chain view via RPC after mining

### DIFF
--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -21,6 +21,8 @@ use smite::noise::{ConnectionError, NoiseConnection};
 use smite::oracles::{AcceptChannelContext, AcceptChannelOracle, Oracle};
 use smite::pending_channel::PendingChannel;
 use smite::violation::Violation;
+
+use super::targets::TargetRpc;
 use smite_ir::operation::AcceptChannelField;
 use smite_ir::{Operation, Program, Variable};
 use std::collections::{HashMap, HashSet};
@@ -229,11 +231,13 @@ pub enum ExecuteError {
 }
 
 /// Executes IR programs against a target over an established connection.
-pub struct Executor<C, B> {
+pub struct Executor<C, B, R> {
     /// Connection used to send and receive Lightning messages.
     conn: C,
     /// Interface to bitcoind for wallet and chain operations.
     bitcoin_cli: B,
+    /// Interface for interacting with the target node through RPC.
+    rpc: R,
     /// Immutable state captured during snapshot setup.
     context: ProgramContext,
     /// Channel states maintained implicitly across program execution, keyed by
@@ -259,13 +263,15 @@ pub struct Executor<C, B> {
     mined_txids: HashSet<Txid>,
 }
 
-impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
-    /// Creates an executor with the given connection, bitcoin-cli handle, and
-    /// program context. Channel state and negotiations start empty.
-    pub fn new(conn: C, bitcoin_cli: B, context: ProgramContext) -> Self {
+impl<C: Connection, B: BitcoinRpc, R: TargetRpc> Executor<C, B, R> {
+    /// Creates an executor with the given connection, bitcoin-cli handle,
+    /// program context, and target RPC handle. Channel state and negotiations
+    /// start empty.
+    pub fn new(conn: C, bitcoin_cli: B, rpc: R, context: ProgramContext) -> Self {
         Self {
             conn,
             bitcoin_cli,
+            rpc,
             context,
             channel_states: HashMap::new(),
             negotiations: HashMap::new(),
@@ -521,6 +527,7 @@ impl<C: Connection, B: BitcoinRpc> Executor<C, B> {
                         .map(|(_, hex)| hex)
                         .collect();
                     self.bitcoin_cli.mine_blocks(*v, &private_mempool);
+                    self.rpc.chain_sync();
                     self.mined_txids.extend(self.unmined_txids.drain());
                     log::debug!("[{:?}] MineBlocks: mined {} block(s)", start.elapsed(), v);
                     None

--- a/smite-scenarios/src/executor/tests.rs
+++ b/smite-scenarios/src/executor/tests.rs
@@ -47,6 +47,7 @@ fn execute_load_build_send() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor
@@ -131,6 +132,7 @@ fn execute_build_channel_announcement() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor
@@ -198,6 +200,7 @@ fn execute_build_node_announcement() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor
@@ -290,6 +293,7 @@ fn execute_build_channel_update() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor
@@ -401,6 +405,7 @@ fn execute_build_announcement_signatures() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor
@@ -494,6 +499,7 @@ fn execute_build_open_channel_with_tlvs() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor
@@ -543,6 +549,7 @@ fn execute_derive_point() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor
@@ -604,6 +611,7 @@ fn execute_recv_and_extract_all_fields() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor.conn.queue_recv(ac_bytes);
@@ -629,6 +637,7 @@ fn execute_recv_unexpected_message() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor.conn.queue_recv(init_bytes);
@@ -662,6 +671,7 @@ fn execute_recv_peer_error() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor.conn.queue_recv(error_bytes);
@@ -694,6 +704,7 @@ fn execute_recv_auto_pong() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor.conn.queue_recv(ping_bytes);
@@ -734,6 +745,7 @@ fn execute_recv_skips_gossip() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor.conn.queue_recv(gossip_bytes);
@@ -770,6 +782,7 @@ fn execute_records_negotiation_for_open_and_accept() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor.conn.queue_recv(ac_bytes);
@@ -810,6 +823,7 @@ fn execute_recv_accept_channel_unknown_channel() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor.conn.queue_recv(ac_bytes);
@@ -854,6 +868,7 @@ fn execute_recv_accept_channel_opener_cannot_afford_fee() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor.conn.queue_recv(ac_bytes);
@@ -902,6 +917,7 @@ fn execute_recv_accept_channel_rejects_reuse_before_funding() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor.conn.queue_recv(ac_bytes.clone());
@@ -954,6 +970,7 @@ fn execute_records_only_first_open_channel_for_duplicate_id_before_funding() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor
@@ -1003,7 +1020,12 @@ fn execute_records_open_channel_for_duplicate_id_after_funding() {
         instrs.push(instr);
     }
 
-    let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+    let mut executor = Executor::new(
+        MockConnection::new(),
+        mock_cli,
+        MockTargetRpc::default(),
+        sample_context(),
+    );
     executor
         .negotiations
         .insert(temporary_channel_id, sample_funding_negotiation());
@@ -1036,6 +1058,7 @@ fn execute_wrong_input_count_panics() {
     let _ = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     )
     .execute(&program, std::time::Instant::now());
@@ -1059,6 +1082,7 @@ fn execute_type_mismatch_panics() {
     let _ = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     )
     .execute(&program, std::time::Instant::now());
@@ -1076,6 +1100,7 @@ fn execute_variable_out_of_bounds_panics() {
     let _ = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     )
     .execute(&program, std::time::Instant::now());
@@ -1099,6 +1124,7 @@ fn execute_forward_variable_reference_panics() {
     let _ = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     )
     .execute(&program, std::time::Instant::now());
@@ -1123,6 +1149,7 @@ fn execute_void_variable_reference_panics() {
     let _ = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     )
     .execute(&program, std::time::Instant::now());
@@ -1146,6 +1173,7 @@ fn execute_invalid_private_key_panics() {
     let _ = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     )
     .execute(&program, std::time::Instant::now());
@@ -1172,6 +1200,7 @@ fn execute_send_open_channel_wrong_type_panics() {
     let _ = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     )
     .execute(&program, std::time::Instant::now());
@@ -1199,6 +1228,7 @@ fn execute_affine_overuse_panics() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor.conn.queue_recv(ac_bytes);
@@ -1218,6 +1248,7 @@ fn execute_mine_blocks_invokes_cli() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor
@@ -1227,6 +1258,7 @@ fn execute_mine_blocks_invokes_cli() {
     // Verify that mine_blocks was called with the correct number
     assert_eq!(executor.bitcoin_cli.mine_blocks_calls, vec![6]);
     assert!(executor.bitcoin_cli.mined_private_mempool.is_empty());
+    assert_eq!(executor.rpc.chain_syncs, 1);
 }
 
 #[test]
@@ -1248,6 +1280,7 @@ fn execute_mine_blocks_wrong_input() {
     let _ = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     )
     .execute(&program, std::time::Instant::now());
@@ -1260,7 +1293,12 @@ fn execute_create_and_broadcast_tx() {
         change_spk: sample_change_spk(),
         ..Default::default()
     };
-    let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+    let mut executor = Executor::new(
+        MockConnection::new(),
+        mock_cli,
+        MockTargetRpc::default(),
+        sample_context(),
+    );
     executor
         .execute(
             &Program {
@@ -1276,6 +1314,7 @@ fn execute_create_and_broadcast_tx() {
         broadcast_tx.compute_txid().to_string(),
         "09b0549b35f14ee862f63bd75811c6c27963c4dea6766ec6836952ec78df1e7e"
     );
+    assert_eq!(executor.rpc.chain_syncs, 0);
 }
 
 // LookupShortChannelId should combine the confirmed block position with
@@ -1303,7 +1342,12 @@ fn execute_lookup_short_channel_id_confirmed() {
     // Build and send a channel_announcement carrying the looked-up SCID.
     instrs.extend(channel_announcement_from_scid_instructions(instrs.len(), 9));
 
-    let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+    let mut executor = Executor::new(
+        MockConnection::new(),
+        mock_cli,
+        MockTargetRpc::default(),
+        sample_context(),
+    );
     executor
         .execute(
             &Program {
@@ -1379,7 +1423,12 @@ fn execute_lookup_short_channel_id_unconfirmed_returns_sentinel() {
     ];
     instrs.extend(channel_announcement_from_scid_instructions(instrs.len(), 7));
 
-    let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+    let mut executor = Executor::new(
+        MockConnection::new(),
+        mock_cli,
+        MockTargetRpc::default(),
+        sample_context(),
+    );
     executor
         .execute(
             &Program {
@@ -1422,7 +1471,12 @@ fn execute_broadcast_dedupes_rejected_tx_in_private_mempool() {
         inputs: vec![],
     });
 
-    let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+    let mut executor = Executor::new(
+        MockConnection::new(),
+        mock_cli,
+        MockTargetRpc::default(),
+        sample_context(),
+    );
     executor
         .execute(
             &Program {
@@ -1459,14 +1513,19 @@ fn execute_create_funding_transaction_insufficient_funds() {
         change_spk: sample_change_spk(),
         ..Default::default()
     };
-    let err = Executor::new(MockConnection::new(), mock_cli, sample_context())
-        .execute(
-            &Program {
-                instructions: create_and_broadcast_tx_instructions(),
-            },
-            std::time::Instant::now(),
-        )
-        .unwrap_err();
+    let err = Executor::new(
+        MockConnection::new(),
+        mock_cli,
+        MockTargetRpc::default(),
+        sample_context(),
+    )
+    .execute(
+        &Program {
+            instructions: create_and_broadcast_tx_instructions(),
+        },
+        std::time::Instant::now(),
+    )
+    .unwrap_err();
     let ExecuteError::InsufficientFunds(funds_err) = err else {
         panic!("expected InsufficientFunds, got {err:?}");
     };
@@ -1499,7 +1558,12 @@ fn execute_send_funding_created_and_recv_funding_signed() {
     })
     .encode();
 
-    let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+    let mut executor = Executor::new(
+        MockConnection::new(),
+        mock_cli,
+        MockTargetRpc::default(),
+        sample_context(),
+    );
     executor.conn.queue_recv(fs_bytes);
     executor.negotiations.insert(
         TemporaryChannelId::new([0xbb; 32]),
@@ -1548,6 +1612,7 @@ fn execute_send_funding_created_and_recv_funding_signed() {
         .get(&TemporaryChannelId::new([0xbb; 32]))
         .unwrap();
     assert!(pending.funding_built);
+    assert_eq!(executor.rpc.chain_syncs, 0);
 }
 
 #[test]
@@ -1580,7 +1645,12 @@ fn execute_send_funding_created_uses_wire_funding_pubkey() {
     let mut instrs = send_funding_created_and_recv_funding_signed_instructions();
     instrs[9].inputs[1] = 2;
 
-    let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+    let mut executor = Executor::new(
+        MockConnection::new(),
+        mock_cli,
+        MockTargetRpc::default(),
+        sample_context(),
+    );
     executor.conn.queue_recv(fs_bytes);
     executor.negotiations.insert(
         TemporaryChannelId::new([0xbb; 32]),
@@ -1657,7 +1727,12 @@ fn execute_send_funding_created_after_funding_built_does_not_track_channel() {
         },
     ]);
 
-    let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+    let mut executor = Executor::new(
+        MockConnection::new(),
+        mock_cli,
+        MockTargetRpc::default(),
+        sample_context(),
+    );
     executor.negotiations.insert(
         TemporaryChannelId::new([0xbb; 32]),
         sample_funding_negotiation(),
@@ -1688,7 +1763,12 @@ fn execute_send_funding_created_push_exceeds_funding() {
         change_spk: sample_change_spk(),
         ..Default::default()
     };
-    let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+    let mut executor = Executor::new(
+        MockConnection::new(),
+        mock_cli,
+        MockTargetRpc::default(),
+        sample_context(),
+    );
     executor
         .negotiations
         .insert(TemporaryChannelId::new([0xbb; 32]), negotiation);
@@ -1717,7 +1797,12 @@ fn execute_send_funding_created_funding_msat_overflow() {
         change_spk: sample_change_spk(),
         ..Default::default()
     };
-    let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+    let mut executor = Executor::new(
+        MockConnection::new(),
+        mock_cli,
+        MockTargetRpc::default(),
+        sample_context(),
+    );
     executor
         .negotiations
         .insert(TemporaryChannelId::new([0xbb; 32]), negotiation);
@@ -1748,7 +1833,12 @@ fn execute_send_funding_created_no_open_channel() {
     let mut instrs = send_funding_created_and_recv_funding_signed_instructions();
     instrs.pop(); // Drop the trailing `RecvFundingSigned` instruction.
 
-    let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+    let mut executor = Executor::new(
+        MockConnection::new(),
+        mock_cli,
+        MockTargetRpc::default(),
+        sample_context(),
+    );
     executor
         .execute(
             &Program {
@@ -1787,7 +1877,12 @@ fn execute_send_funding_created_no_accept_channel() {
     let mut instrs = send_funding_created_and_recv_funding_signed_instructions();
     instrs.pop(); // Drop the trailing `RecvFundingSigned` instruction.
 
-    let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+    let mut executor = Executor::new(
+        MockConnection::new(),
+        mock_cli,
+        MockTargetRpc::default(),
+        sample_context(),
+    );
     executor
         .negotiations
         .insert(TemporaryChannelId::new([0xbb; 32]), negotiation);
@@ -1832,7 +1927,12 @@ fn execute_recv_funding_signed_unknown_channel() {
     })
     .encode();
 
-    let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+    let mut executor = Executor::new(
+        MockConnection::new(),
+        mock_cli,
+        MockTargetRpc::default(),
+        sample_context(),
+    );
     executor.conn.queue_recv(fs_bytes);
     executor.negotiations.insert(
         TemporaryChannelId::new([0xbb; 32]),
@@ -1872,7 +1972,12 @@ fn execute_recv_funding_signed_invalid_signature() {
     })
     .encode();
 
-    let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+    let mut executor = Executor::new(
+        MockConnection::new(),
+        mock_cli,
+        MockTargetRpc::default(),
+        sample_context(),
+    );
     executor.conn.queue_recv(fs_bytes);
     executor.negotiations.insert(
         TemporaryChannelId::new([0xbb; 32]),
@@ -1940,7 +2045,12 @@ fn execute_send_channel_ready() {
         signature: "304402203dbf3dbf337b042a72576488c1fb019086089d8d790a47f652346cff2511b6e70220395fdf700cb82b0abfcfe8e0b7c822181f2ee72409c82c3ff8e04e36593662c7".parse().unwrap(),
     })
     .encode();
-    let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+    let mut executor = Executor::new(
+        MockConnection::new(),
+        mock_cli,
+        MockTargetRpc::default(),
+        sample_context(),
+    );
     executor.conn.queue_recv(fs_bytes);
     executor.negotiations.insert(
         TemporaryChannelId::new([0xbb; 32]),
@@ -2012,6 +2122,7 @@ fn execute_send_shutdown() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor
@@ -2052,6 +2163,7 @@ fn execute_send_shutdown_empty_scriptpubkey() {
     let mut executor = Executor::new(
         MockConnection::new(),
         MockBitcoinCli::default(),
+        MockTargetRpc::default(),
         sample_context(),
     );
     executor
@@ -2068,7 +2180,7 @@ fn execute_send_shutdown_empty_scriptpubkey() {
 }
 
 fn recv_channel_ready_executor() -> (
-    Executor<MockConnection, MockBitcoinCli>,
+    Executor<MockConnection, MockBitcoinCli, MockTargetRpc>,
     ChannelId,
     PublicKey,
 ) {
@@ -2102,7 +2214,12 @@ fn recv_channel_ready_executor() -> (
     })
     .encode();
 
-    let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
+    let mut executor = Executor::new(
+        MockConnection::new(),
+        mock_cli,
+        MockTargetRpc::default(),
+        sample_context(),
+    );
     executor.conn.queue_recv(fs_bytes);
     executor.conn.queue_recv(cr_bytes);
     executor.negotiations.insert(

--- a/smite-scenarios/src/executor/tests/harness.rs
+++ b/smite-scenarios/src/executor/tests/harness.rs
@@ -111,6 +111,19 @@ impl BitcoinRpc for MockBitcoinCli {
     }
 }
 
+// Mocking TargetRpc via MockTargetRpc
+
+#[derive(Default)]
+pub struct MockTargetRpc {
+    pub chain_syncs: usize,
+}
+
+impl TargetRpc for MockTargetRpc {
+    fn chain_sync(&mut self) {
+        self.chain_syncs += 1;
+    }
+}
+
 // -- Helpers --
 
 pub fn sample_pubkey(byte: u8) -> PublicKey {

--- a/smite-scenarios/src/scenarios/ir.rs
+++ b/smite-scenarios/src/scenarios/ir.rs
@@ -21,10 +21,10 @@ use crate::targets::Target;
 /// (out-of-bounds variable refs, type mismatches, `MineBlocks(0)`, etc.).
 pub struct IrScenario<T: Target, S: SnapshotSetup<T>> {
     target: T,
-    /// Executes IR programs and owns the connection, bitcoin-cli handle, and
-    /// program context. Created once before the snapshot and reused across
-    /// fuzzing runs.
-    executor: Executor<NoiseConnection, BitcoinCli>,
+    /// Executes IR programs and owns the connection, bitcoin-cli handle,
+    /// program context, and the target's RPC handle. Created once before the
+    /// snapshot and reused across fuzzing runs.
+    executor: Executor<NoiseConnection, BitcoinCli, T::Rpc>,
     // S is only used for static dispatch on S::setup(), not stored.
     _phantom: PhantomData<S>,
 }
@@ -34,7 +34,7 @@ impl<T: Target, S: SnapshotSetup<T>> Scenario for IrScenario<T, S> {
         let target = T::start(T::Config::default())?;
         let (conn, context) = S::setup(&target)?;
         let bitcoin_cli = target.bitcoin_cli().clone();
-        let executor = Executor::new(conn, bitcoin_cli, context);
+        let executor = Executor::new(conn, bitcoin_cli, target.rpc(), context);
         Ok(Self {
             target,
             executor,

--- a/smite-scenarios/src/targets.rs
+++ b/smite-scenarios/src/targets.rs
@@ -7,10 +7,10 @@ mod ldk;
 mod lnd;
 
 pub use bitcoind::INITIAL_BLOCKS;
-pub use cln::{ClnConfig, ClnTarget};
-pub use eclair::{EclairConfig, EclairTarget};
-pub use ldk::{LdkConfig, LdkTarget};
-pub use lnd::{LndConfig, LndTarget};
+pub use cln::{ClnConfig, ClnRpc, ClnTarget};
+pub use eclair::{EclairConfig, EclairRpc, EclairTarget};
+pub use ldk::{LdkConfig, LdkRpc, LdkTarget};
+pub use lnd::{LndConfig, LndRpc, LndTarget};
 use smite::bitcoin::BitcoinCli;
 use smite::scenarios::TargetError;
 
@@ -42,6 +42,13 @@ pub fn check_crash_log() -> Result<(), TargetError> {
     Ok(())
 }
 
+/// Abstraction over target RPC operations for executing commands on a running
+/// target, allowing target-specific implementations.
+pub trait TargetRpc {
+    /// Notifies the target of newly mined blocks so it updates its chain view.
+    fn chain_sync(&mut self);
+}
+
 /// A Lightning implementation that can be fuzzed.
 ///
 /// This trait abstracts over different Lightning implementations (LND, CLN, LDK, etc.),
@@ -49,6 +56,9 @@ pub fn check_crash_log() -> Result<(), TargetError> {
 pub trait Target: Sized {
     /// Configuration for this target.
     type Config: Default;
+
+    /// RPC handle for this target.
+    type Rpc: TargetRpc;
 
     /// Start the target and any dependencies (e.g., bitcoind).
     ///
@@ -62,6 +72,9 @@ pub trait Target: Sized {
 
     /// Target's P2P listen address.
     fn addr(&self) -> SocketAddr;
+
+    /// Target's RPC handle for executing commands.
+    fn rpc(&self) -> Self::Rpc;
 
     /// `bitcoin-cli` wrapper for the regtest `bitcoind` instance.
     fn bitcoin_cli(&self) -> &BitcoinCli;

--- a/smite-scenarios/src/targets/cln.rs
+++ b/smite-scenarios/src/targets/cln.rs
@@ -9,7 +9,9 @@
 //! This means checking lightningd's liveness is sufficient for crash detection.
 
 use std::fs;
+use std::io::{self, ErrorKind};
 use std::net::SocketAddr;
+use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Duration;
@@ -20,7 +22,7 @@ use smite::bitcoin::BitcoinCli;
 use smite::process::ManagedProcess;
 
 use super::bitcoind;
-use super::{Target, TargetError, check_crash_log};
+use super::{Target, TargetError, TargetRpc, check_crash_log};
 
 /// Configuration for the CLN target.
 pub struct ClnConfig {
@@ -43,15 +45,120 @@ impl Default for ClnConfig {
 }
 
 impl ClnConfig {
-    fn bitcoind_config(&self, data_dir: &Path) -> bitcoind::BitcoindConfig {
+    fn bitcoind_config(&self) -> bitcoind::BitcoindConfig {
         bitcoind::BitcoindConfig {
             rpc_port: self.bitcoind_rpc_port,
             p2p_port: self.bitcoind_p2p_port,
-            extra_args: vec![format!(
-                "-blocknotify=lightning-cli --lightning-dir='{}' --network=regtest syncblocks",
-                data_dir.join("cln").display()
-            )],
             ..bitcoind::BitcoindConfig::default()
+        }
+    }
+}
+
+/// RPC handle for interacting with CLN node target.
+#[derive(Debug, Clone)]
+pub struct ClnRpc {
+    /// Path to the CLN node's unix RPC socket.
+    rpc_socket: PathBuf,
+}
+
+impl ClnRpc {
+    /// Bound RPC socket I/O so a stalled lightningd cannot block indefinitely.
+    const RPC_IO_TIMEOUT: Duration = Duration::from_secs(1);
+
+    /// Sends a JSON-RPC request to CLN over its Unix RPC socket and returns the
+    /// `result` of the response.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`io::Error`] only when lightningd is unreachable: the socket
+    /// cannot be connected to, or the reply times out, is cut short or never
+    /// arrives. That is a symptom of an earlier crash/hang rather than a fault
+    /// in the call.
+    ///
+    /// # Panics
+    ///
+    /// If `params` cannot be serialized, the reply is not valid JSON-RPC, or
+    /// CLN answers with a JSON-RPC `error` object.
+    fn run(&self, method: &str, params: impl serde::Serialize) -> io::Result<serde_json::Value> {
+        /// A JSON-RPC response from lightningd. `jsonrpc` and `id` are echoed
+        /// back but unused, and exactly one of `result` or `error` is set.
+        #[derive(Deserialize)]
+        struct RpcResponse {
+            #[serde(default)]
+            result: serde_json::Value,
+            error: Option<serde_json::Value>,
+        }
+
+        let response = (|| -> io::Result<RpcResponse> {
+            // Connect to lightningd's RPC socket.
+            let mut sock = UnixStream::connect(&self.rpc_socket)?;
+            sock.set_read_timeout(Some(Self::RPC_IO_TIMEOUT))
+                .expect("valid timeout");
+            sock.set_write_timeout(Some(Self::RPC_IO_TIMEOUT))
+                .expect("valid timeout");
+
+            // Write the request to the socket.
+            let request = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": "smite",
+                "method": method,
+                "params": params,
+            });
+            serde_json::to_writer(&mut sock, &request)?;
+
+            // Read the response.
+            serde_json::Deserializer::from_reader(&mut sock)
+                .into_iter()
+                .next()
+                .transpose()?
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        format!("lightningd closed the socket without answering {method}"),
+                    )
+                })
+        })();
+
+        // Return errors that may indicate the target crashed or hung so
+        // `check_alive/ping-pong` can classify them later. Any other error
+        // indicates a malformed request or a complete response that is not
+        // valid JSON-RPC.
+        let response = match response {
+            Ok(response) => response,
+            Err(e) => match e.kind() {
+                ErrorKind::ConnectionRefused
+                | ErrorKind::ConnectionReset
+                | ErrorKind::ConnectionAborted
+                | ErrorKind::BrokenPipe
+                | ErrorKind::WouldBlock
+                | ErrorKind::TimedOut
+                | ErrorKind::UnexpectedEof => return Err(e),
+                _ => panic!("malformed {method} request or response: {e}"),
+            },
+        };
+
+        if let Some(error) = response.error {
+            panic!("lightningd rejected {method}: {error}");
+        }
+
+        Ok(response.result)
+    }
+}
+
+impl TargetRpc for ClnRpc {
+    /// RPC to make CLN poll for new blocks immediately instead of waiting for
+    /// its regular poll interval, allowing it to sync faster.
+    ///
+    /// # Panics
+    ///
+    /// - If lightningd answers with an error, which means the call itself is at
+    ///   fault rather than the target having crashed/hanged.
+    fn chain_sync(&mut self) {
+        if let Err(e) = self.run("syncblocks", serde_json::json!({})) {
+            // lightningd is unreachable, indicating that CLN has already
+            // crashed/hanged, check_alive/ping-pong will report the crash/hang
+            // at the end.
+            log::warn!("syncblocks could not reach lightningd: {e}");
         }
     }
 }
@@ -207,12 +314,12 @@ impl Drop for ClnTarget {
 
 impl Target for ClnTarget {
     type Config = ClnConfig;
+    type Rpc = ClnRpc;
 
     fn start(config: Self::Config) -> Result<Self, TargetError> {
         let (data_path, temp_dir) = bitcoind::resolve_data_dir()?;
 
-        let bitcoind_config = config.bitcoind_config(&data_path);
-        let (bitcoind, bitcoin_cli) = bitcoind::start(&bitcoind_config, &data_path)?;
+        let (bitcoind, bitcoin_cli) = bitcoind::start(&config.bitcoind_config(), &data_path)?;
         let (cln, pubkey, cln_dir) = Self::start_cln(&config, &data_path)?;
         let addr = SocketAddr::from(([127, 0, 0, 1], config.cln_p2p_port));
 
@@ -235,6 +342,12 @@ impl Target for ClnTarget {
 
     fn addr(&self) -> SocketAddr {
         self.addr
+    }
+
+    fn rpc(&self) -> Self::Rpc {
+        ClnRpc {
+            rpc_socket: self.cln_dir.join("regtest").join("lightning-rpc"),
+        }
     }
 
     fn bitcoin_cli(&self) -> &BitcoinCli {

--- a/smite-scenarios/src/targets/eclair.rs
+++ b/smite-scenarios/src/targets/eclair.rs
@@ -16,7 +16,7 @@ use smite::bitcoin::BitcoinCli;
 use smite::process::ManagedProcess;
 
 use super::bitcoind;
-use super::{Target, TargetError, check_crash_log};
+use super::{Target, TargetError, TargetRpc, check_crash_log};
 
 /// API password for Eclair's REST API.
 const API_PASSWORD: &str = "fuzzpass";
@@ -62,6 +62,16 @@ impl EclairConfig {
             ..bitcoind::BitcoindConfig::default()
         }
     }
+}
+
+/// RPC handle for interacting with eclair node target.
+#[derive(Debug, Clone)]
+pub struct EclairRpc;
+
+impl TargetRpc for EclairRpc {
+    /// Eclair receives new blocks directly from bitcoind over ZMQ, so no manual
+    /// chain synchronization is required.
+    fn chain_sync(&mut self) {}
 }
 
 /// Eclair Lightning node target.
@@ -197,6 +207,7 @@ impl EclairTarget {
 
 impl Target for EclairTarget {
     type Config = EclairConfig;
+    type Rpc = EclairRpc;
 
     fn start(config: Self::Config) -> Result<Self, TargetError> {
         let (data_path, temp_dir) = bitcoind::resolve_data_dir()?;
@@ -223,6 +234,10 @@ impl Target for EclairTarget {
 
     fn addr(&self) -> SocketAddr {
         self.addr
+    }
+
+    fn rpc(&self) -> Self::Rpc {
+        EclairRpc
     }
 
     fn bitcoin_cli(&self) -> &BitcoinCli {

--- a/smite-scenarios/src/targets/ldk.rs
+++ b/smite-scenarios/src/targets/ldk.rs
@@ -11,10 +11,10 @@ use std::process::{Command, Stdio};
 
 use bitcoin::secp256k1;
 use smite::bitcoin::BitcoinCli;
-use smite::process::ManagedProcess;
+use smite::process::{ManagedProcess, send_sigusr1};
 
 use super::bitcoind;
-use super::{Target, TargetError, check_crash_log};
+use super::{Target, TargetError, TargetRpc, check_crash_log};
 
 /// Configuration for the LDK target.
 pub struct LdkConfig {
@@ -41,10 +41,39 @@ impl LdkConfig {
         bitcoind::BitcoindConfig {
             rpc_port: self.bitcoind_rpc_port,
             p2p_port: self.bitcoind_p2p_port,
-            // signals the wrapper (SIGUSR1) to sync on each new block instead
-            // of waiting for the next poll.
-            extra_args: vec!["-blocknotify=pkill -USR1 -f ^ldk-node-wrapper".to_string()],
             ..bitcoind::BitcoindConfig::default()
+        }
+    }
+}
+
+/// RPC handle for interacting with LDK node target.
+///
+/// LDK currently has no RPC socket, so commands are delivered through signals
+/// that invoke the corresponding APIs directly.
+#[derive(Debug, Clone)]
+pub struct LdkRpc {
+    /// PID of the LDK node's wrapper process, which receives the signals.
+    pid: u32,
+}
+
+impl TargetRpc for LdkRpc {
+    /// Signals the wrapper (SIGUSR1) to sync on new blocks immediately instead
+    /// of waiting for its regular poll interval, allowing it to sync faster.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the signal cannot be sent, which means the call itself is at
+    /// fault rather than the target having crashed or hung.
+    fn chain_sync(&mut self) {
+        // A crashed wrapper remains an unreaped zombie, so the signal is sent
+        // but discarded. A hung wrapper is still alive, so the signal stays
+        // pending until it resumes. check_alive/ping-pong reports the
+        // crash/hang at the end.
+        if let Err(e) = send_sigusr1(self.pid) {
+            panic!(
+                "failed to send SIGUSR1 to ldk-node-wrapper (pid {}): {e}",
+                self.pid
+            );
         }
     }
 }
@@ -90,28 +119,6 @@ impl LdkTarget {
             cmd.env("LD_PRELOAD", handler);
         }
 
-        // Ignore SIGUSR1 for the window between exec and the wrapper blocking
-        // it. Initial-block generation triggers a burst of asynchronous
-        // `-blocknotify` (`pkill -USR1`), and a stray one landing in that window
-        // would kill the wrapper, since SIGUSR1 is fatal by default. SIG_IGN
-        // survives exec; a caught handler would not.
-        //
-        // Signals arriving while SIG_IGN is in effect are dropped, but that ends
-        // once the wrapper calls `pthread_sigmask(SIG_BLOCK)`: blocking wins over
-        // the disposition, so SIGUSR1 then stays pending for `sigwait()` instead
-        // of being discarded. SIG_IGN therefore stays in effect for the whole run
-        // and the wrapper never needs to replace it.
-        //
-        // SAFETY: runs in the child after fork, before exec; calls only the
-        // async-signal-safe `signal`.
-        unsafe {
-            use std::os::unix::process::CommandExt;
-            cmd.pre_exec(|| {
-                libc::signal(libc::SIGUSR1, libc::SIG_IGN);
-                Ok(())
-            });
-        }
-
         let mut ldk = ManagedProcess::spawn(&mut cmd, "ldk-node-wrapper")?;
 
         // Parse pubkey from stdout. The wrapper prints:
@@ -150,6 +157,7 @@ impl LdkTarget {
 
 impl Target for LdkTarget {
     type Config = LdkConfig;
+    type Rpc = LdkRpc;
 
     fn start(config: Self::Config) -> Result<Self, TargetError> {
         let (data_path, temp_dir) = bitcoind::resolve_data_dir()?;
@@ -176,6 +184,12 @@ impl Target for LdkTarget {
 
     fn addr(&self) -> SocketAddr {
         self.addr
+    }
+
+    fn rpc(&self) -> Self::Rpc {
+        LdkRpc {
+            pid: self.ldk.pid(),
+        }
     }
 
     fn bitcoin_cli(&self) -> &BitcoinCli {

--- a/smite-scenarios/src/targets/lnd.rs
+++ b/smite-scenarios/src/targets/lnd.rs
@@ -14,7 +14,7 @@ use smite::bitcoin::BitcoinCli;
 use smite::process::ManagedProcess;
 
 use super::bitcoind;
-use super::{Target, TargetError};
+use super::{Target, TargetError, TargetRpc};
 
 /// Configuration for the LND target.
 pub struct LndConfig {
@@ -79,6 +79,16 @@ impl CoveragePipes {
         self.ack_read.read_exact(&mut buf)?;
         Ok(())
     }
+}
+
+/// RPC handle for interacting with LND node target.
+#[derive(Debug, Clone)]
+pub struct LndRpc;
+
+impl TargetRpc for LndRpc {
+    /// LND receives new blocks directly from bitcoind over ZMQ, so no manual
+    /// chain synchronization is required.
+    fn chain_sync(&mut self) {}
 }
 
 /// LND Lightning node target.
@@ -271,6 +281,7 @@ impl LndTarget {
 
 impl Target for LndTarget {
     type Config = LndConfig;
+    type Rpc = LndRpc;
 
     fn start(config: Self::Config) -> Result<Self, TargetError> {
         let (data_path, temp_dir) = bitcoind::resolve_data_dir()?;
@@ -298,6 +309,10 @@ impl Target for LndTarget {
 
     fn addr(&self) -> SocketAddr {
         self.addr
+    }
+
+    fn rpc(&self) -> Self::Rpc {
+        LndRpc
     }
 
     fn bitcoin_cli(&self) -> &BitcoinCli {

--- a/smite/src/process.rs
+++ b/smite/src/process.rs
@@ -8,7 +8,7 @@ use std::os::unix::process::CommandExt;
 use std::process::{Child, Command, ExitStatus};
 use std::time::{Duration, Instant};
 
-use nix::sys::signal::{Signal, killpg};
+use nix::sys::signal::{Signal, kill, killpg};
 use nix::unistd::Pid;
 
 /// A managed subprocess with graceful shutdown support.
@@ -151,6 +151,19 @@ impl Drop for ManagedProcess {
             }
         }
     }
+}
+
+/// Sends SIGUSR1 to the process with the given `pid`.
+///
+/// # Errors
+///
+/// Returns an error if `pid` exceeds `i32::MAX` or if sending the signal fails.
+pub fn send_sigusr1(pid: u32) -> io::Result<()> {
+    let pid = i32::try_from(pid)
+        .map(Pid::from_raw)
+        .map_err(|_| io::Error::other("pid exceeds i32::MAX"))?;
+
+    kill(pid, Signal::SIGUSR1).map_err(Into::into)
 }
 
 #[cfg(test)]

--- a/workloads/ldk/src/main.rs
+++ b/workloads/ldk/src/main.rs
@@ -32,12 +32,10 @@ fn install_panic_hook() {
 /// with `sigwait()`.
 ///
 /// Blocking supersedes the disposition inherited across exec, which for SIGUSR1
-/// is `SIG_IGN` (set by the scenario's pre-exec hook, see `LdkTarget::start`).
-/// That distinction is the whole point: an *ignored* signal is discarded the
-/// moment it is delivered, while a *blocked* one stays pending until `sigwait()`
-/// consumes it, regardless of its disposition. So this call is what makes
-/// bitcoind's `-blocknotify` SIGUSR1 observable, and why nothing here calls
-/// `sigaction`: the wait loop below is the only consumer these signals need.
+/// defaults to terminating the process. A blocked SIGUSR1 stays pending until
+/// `sigwait()` consumes it, regardless of its disposition. So this call is what
+/// makes target's SIGUSR1 observable, and why nothing here calls `sigaction`:
+/// the wait loop below is the only consumer these signals need.
 ///
 /// Standard signals do not queue, so a burst of SIGUSR1 collapses into one
 /// pending instance and thus one wakeup. That is fine here: each wakeup syncs
@@ -64,7 +62,7 @@ fn setup_signal_set() -> libc::sigset_t {
 fn main() {
     install_panic_hook();
 
-    // bitcoind's -blocknotify sends SIGUSR1 for each new block.
+    // The target sends SIGUSR1 to request an immediate chain sync.
     // SIGTERM/SIGINT are used for graceful shutdown.
     let signal_set = setup_signal_set();
 
@@ -114,7 +112,7 @@ fn main() {
     println!("READY");
 
     // Wait for signals. sigwait() blocks here without polling and returns
-    // immediately when bitcoind sends SIGUSR1 or the process receives
+    // immediately when the target sends SIGUSR1 or the process receives
     // SIGTERM/SIGINT.
     loop {
         let mut signal = 0;
@@ -126,13 +124,13 @@ fn main() {
 
         match signal {
             libc::SIGUSR1 => {
-                // Sync the wallet whenever bitcoind signals a new block.
+                // Sync the wallet whenever the target asks for it.
                 // ldk-node's own 2s background poll keeps running, so this is
                 // technically redundant and may race it, but that's safe:
                 // ldk-node coalesces concurrent syncs, so whichever loses the
                 // race just waits on the in-flight sync's result rather than
                 // applying the block twice. We accept the redundancy to sync on
-                // the block instead of up to 2s later.
+                // demand instead of up to 2s later.
                 if let Err(e) = node.sync_wallets() {
                     eprintln!("sync_wallets failed: {e}");
                 }


### PR DESCRIPTION
ref: #195 

Targets (CLN, LDK) previously learned about new blocks through bitcoind's `blocknotify`, which fires asynchronously. When multiple blocks are mined, this can queue up many sync calls, adding unnecessary load. Instead, explicitly sync the target once after each `MineBlocks` operation.
Introduce a `TargetRpc` trait with a `chain_sync()` method, called by the executor immediately after `MineBlocks`. CLN and LDK sync explicitly via RPC and signals, respectively, while LND and Eclair use ZMQ and remain no-ops.
Dropping `-blocknotify` also removes the burst of asynchronous `SIGUSR1`s during initial block generation, so LDK no longer needs the `pre_exec` `SIG_IGN`

The reason I went with an RPC trait is that, in the future, we'll need access to the target's CLI/RPC to add payment hash and preimage information to the target so that it can send an `update_fulfill_htlc` message.
Also, for now, I only added the CLI as a trait implementation for each target to keep the changes contained and concise. In the future, we can definitely add direct RPC calls over the socket as well to save overhead.