### PR TITLE
smite: name the temporary_channel_id with a type alias

### DIFF
--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -11,6 +11,7 @@ use smite::bolt::{
     AcceptChannel, AnnouncementSignatures, ChannelAnnouncement, ChannelId, ChannelReady,
     ChannelReadyTlvs, ChannelUpdate, Features, FundingCreated, FundingSigned, Message, MessageType,
     NodeAnnouncement, OpenChannel, OpenChannelTlvs, Pong, ShortChannelId, Shutdown,
+    TemporaryChannelId,
 };
 use smite::channel_tx::{
     ChannelConfig, ChannelPartyConfig, ChannelState, FundingTransaction, HolderIdentity, Side,
@@ -243,7 +244,7 @@ pub struct Executor<C, B> {
     /// Negotiation state captured during program execution, keyed by
     /// `temporary_channel_id`, so the funding flow can build commitments from
     /// the parameters actually sent on the wire.
-    negotiations: HashMap<ChannelId, PendingChannel>,
+    negotiations: HashMap<TemporaryChannelId, PendingChannel>,
     /// Transactions stored outside Bitcoin Core's mempool, typically because they
     /// were rejected by mempool policy, to be included in the next `MineBlocks`
     /// operation. Each is stored as `(txid, raw_hex)`: re-signing the same
@@ -879,7 +880,7 @@ fn build_funding_created(
     variables: &[Option<Variable>],
     inputs: &[usize],
     channel_states: &mut HashMap<ChannelId, ChannelState>,
-    negotiations: &mut HashMap<ChannelId, PendingChannel>,
+    negotiations: &mut HashMap<TemporaryChannelId, PendingChannel>,
     mined_txids: &HashSet<Txid>,
 ) -> Result<FundingCreated, ExecuteError> {
     let funding_tx = resolve_funding_transaction(variables, inputs[0]);
@@ -1361,7 +1362,7 @@ fn verify_funding_signed(
 /// `funding_created` has been built, it is overwritten, allowing the
 /// `temporary_channel_id` to be reused for a new negotiation.
 fn record_send_open_channel(
-    negotiations: &mut HashMap<ChannelId, PendingChannel>,
+    negotiations: &mut HashMap<TemporaryChannelId, PendingChannel>,
     open_channel: &OpenChannel,
 ) {
     if negotiations
@@ -1389,7 +1390,7 @@ fn record_send_open_channel(
 /// Panics if no matching `open_channel` exists. This should be unreachable, as
 /// `AcceptChannelOracle` reports such messages as a [`Violation`].
 fn record_recv_accept_channel(
-    negotiations: &mut HashMap<ChannelId, PendingChannel>,
+    negotiations: &mut HashMap<TemporaryChannelId, PendingChannel>,
     accept_channel: &AcceptChannel,
 ) {
     negotiations
@@ -1600,7 +1601,7 @@ mod tests {
 
     fn sample_accept_channel() -> AcceptChannel {
         AcceptChannel {
-            temporary_channel_id: ChannelId::new([0xbb; 32]),
+            temporary_channel_id: TemporaryChannelId::new([0xbb; 32]),
             dust_limit_satoshis: 546,
             max_htlc_value_in_flight_msat: 100_000_000,
             channel_reserve_satoshis: 10_000,
@@ -1869,7 +1870,7 @@ mod tests {
         assert_eq!(executor.conn.sent.len(), 1);
         let oc = decode_open_channel(&executor.conn.sent[0]);
         assert_eq!(oc.chain_hash, [0xcc; 32]);
-        assert_eq!(oc.temporary_channel_id, ChannelId::new([0xbb; 32]));
+        assert_eq!(oc.temporary_channel_id, TemporaryChannelId::new([0xbb; 32]));
         assert_eq!(oc.funding_satoshis, 100_000);
         assert_eq!(oc.push_msat, 0);
         assert_eq!(oc.dust_limit_satoshis, 546);
@@ -2573,7 +2574,7 @@ mod tests {
 
     #[test]
     fn execute_records_negotiation_for_open_and_accept() {
-        let temporary_channel_id = ChannelId::new([0xbb; 32]);
+        let temporary_channel_id = TemporaryChannelId::new([0xbb; 32]);
         let ac_bytes = Message::AcceptChannel(sample_accept_channel()).encode();
 
         let mut instrs = send_open_channel_instructions();
@@ -2609,7 +2610,7 @@ mod tests {
 
     #[test]
     fn execute_recv_accept_channel_unknown_channel() {
-        let unknown_id = ChannelId::new([0xcc; 32]);
+        let unknown_id = TemporaryChannelId::new([0xcc; 32]);
         let ac_bytes = Message::AcceptChannel(AcceptChannel {
             temporary_channel_id: unknown_id,
             ..sample_accept_channel()
@@ -2648,7 +2649,7 @@ mod tests {
 
     #[test]
     fn execute_recv_accept_channel_opener_cannot_afford_fee() {
-        let temporary_channel_id = ChannelId::new([0xbb; 32]);
+        let temporary_channel_id = TemporaryChannelId::new([0xbb; 32]);
         let ac_bytes = Message::AcceptChannel(sample_accept_channel()).encode();
 
         // Set `push_msat` so the opener cannot afford the commitment fee
@@ -2690,7 +2691,7 @@ mod tests {
 
     #[test]
     fn execute_recv_accept_channel_rejects_reuse_before_funding() {
-        let temporary_channel_id = ChannelId::new([0xbb; 32]);
+        let temporary_channel_id = TemporaryChannelId::new([0xbb; 32]);
         let ac_bytes = Message::AcceptChannel(sample_accept_channel()).encode();
 
         let mut instrs = send_open_channel_instructions();
@@ -2737,7 +2738,7 @@ mod tests {
 
     #[test]
     fn execute_records_only_first_open_channel_for_duplicate_id_before_funding() {
-        let temporary_channel_id = ChannelId::new([0xbb; 32]);
+        let temporary_channel_id = TemporaryChannelId::new([0xbb; 32]);
 
         // First open_channel: funding_satoshis = 100_000.
         // Second open_channel: same temporary_channel_id, funding_satoshis = 200_000.
@@ -2793,7 +2794,7 @@ mod tests {
 
     #[test]
     fn execute_records_open_channel_for_duplicate_id_after_funding() {
-        let temporary_channel_id = ChannelId::new([0xbb; 32]);
+        let temporary_channel_id = TemporaryChannelId::new([0xbb; 32]);
         let mock_cli = MockBitcoinCli {
             utxos: vec![sample_utxo()],
             change_spk: sample_change_spk(),
@@ -3300,7 +3301,7 @@ mod tests {
         PendingChannel {
             open_channel: OpenChannel {
                 chain_hash: [0xcc; 32],
-                temporary_channel_id: ChannelId::new([0xbb; 32]),
+                temporary_channel_id: TemporaryChannelId::new([0xbb; 32]),
                 funding_satoshis: 10_000_000,
                 push_msat: 3_000_000_000,
                 dust_limit_satoshis: 546,
@@ -3320,7 +3321,7 @@ mod tests {
                 tlvs: OpenChannelTlvs::default(),
             },
             accept_channel: Some(AcceptChannel {
-                temporary_channel_id: ChannelId::new([0xbb; 32]),
+                temporary_channel_id: TemporaryChannelId::new([0xbb; 32]),
                 dust_limit_satoshis: 546,
                 max_htlc_value_in_flight_msat: 100_000_000,
                 channel_reserve_satoshis: 10_000,
@@ -3386,9 +3387,10 @@ mod tests {
 
         let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
         executor.conn.queue_recv(fs_bytes);
-        executor
-            .negotiations
-            .insert(ChannelId::new([0xbb; 32]), sample_funding_negotiation());
+        executor.negotiations.insert(
+            TemporaryChannelId::new([0xbb; 32]),
+            sample_funding_negotiation(),
+        );
         executor
             .execute(
                 &Program {
@@ -3404,7 +3406,7 @@ mod tests {
             other => panic!("expected funding_created(34), got {other}"),
         };
 
-        assert_eq!(fc.temporary_channel_id, ChannelId::new([0xbb; 32]));
+        assert_eq!(fc.temporary_channel_id, TemporaryChannelId::new([0xbb; 32]));
         assert_eq!(
             fc.funding_txid.to_string(),
             "09b0549b35f14ee862f63bd75811c6c27963c4dea6766ec6836952ec78df1e7e"
@@ -3429,7 +3431,7 @@ mod tests {
 
         let pending = executor
             .negotiations
-            .get(&ChannelId::new([0xbb; 32]))
+            .get(&TemporaryChannelId::new([0xbb; 32]))
             .unwrap();
         assert!(pending.funding_built);
     }
@@ -3466,9 +3468,10 @@ mod tests {
 
         let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
         executor.conn.queue_recv(fs_bytes);
-        executor
-            .negotiations
-            .insert(ChannelId::new([0xbb; 32]), sample_funding_negotiation());
+        executor.negotiations.insert(
+            TemporaryChannelId::new([0xbb; 32]),
+            sample_funding_negotiation(),
+        );
         // The acceptor's funding_signed still verifies, because the config is
         // built from the wire pubkeys rather than from the swapped privkey.
         executor
@@ -3543,9 +3546,10 @@ mod tests {
         ]);
 
         let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
-        executor
-            .negotiations
-            .insert(ChannelId::new([0xbb; 32]), sample_funding_negotiation());
+        executor.negotiations.insert(
+            TemporaryChannelId::new([0xbb; 32]),
+            sample_funding_negotiation(),
+        );
         executor
             .execute(
                 &Program {
@@ -3575,7 +3579,7 @@ mod tests {
         let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
         executor
             .negotiations
-            .insert(ChannelId::new([0xbb; 32]), negotiation);
+            .insert(TemporaryChannelId::new([0xbb; 32]), negotiation);
         let err = executor
             .execute(
                 &Program {
@@ -3604,7 +3608,7 @@ mod tests {
         let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
         executor
             .negotiations
-            .insert(ChannelId::new([0xbb; 32]), negotiation);
+            .insert(TemporaryChannelId::new([0xbb; 32]), negotiation);
         let err = executor
             .execute(
                 &Program {
@@ -3646,7 +3650,7 @@ mod tests {
             Message::FundingCreated(fc) => fc,
             other => panic!("expected funding_created(34), got {other}"),
         };
-        assert_eq!(fc.temporary_channel_id, ChannelId::new([0xbb; 32]));
+        assert_eq!(fc.temporary_channel_id, TemporaryChannelId::new([0xbb; 32]));
         assert_eq!(
             fc.funding_txid.to_string(),
             "09b0549b35f14ee862f63bd75811c6c27963c4dea6766ec6836952ec78df1e7e"
@@ -3674,7 +3678,7 @@ mod tests {
         let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
         executor
             .negotiations
-            .insert(ChannelId::new([0xbb; 32]), negotiation);
+            .insert(TemporaryChannelId::new([0xbb; 32]), negotiation);
         executor
             .execute(
                 &Program {
@@ -3688,7 +3692,7 @@ mod tests {
             Message::FundingCreated(fc) => fc,
             other => panic!("expected funding_created(34), got {other}"),
         };
-        assert_eq!(fc.temporary_channel_id, ChannelId::new([0xbb; 32]));
+        assert_eq!(fc.temporary_channel_id, TemporaryChannelId::new([0xbb; 32]));
         assert_eq!(
             fc.funding_txid.to_string(),
             "09b0549b35f14ee862f63bd75811c6c27963c4dea6766ec6836952ec78df1e7e"
@@ -3718,9 +3722,10 @@ mod tests {
 
         let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
         executor.conn.queue_recv(fs_bytes);
-        executor
-            .negotiations
-            .insert(ChannelId::new([0xbb; 32]), sample_funding_negotiation());
+        executor.negotiations.insert(
+            TemporaryChannelId::new([0xbb; 32]),
+            sample_funding_negotiation(),
+        );
         let err = executor
             .execute(
                 &Program {
@@ -3758,9 +3763,10 @@ mod tests {
 
         let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
         executor.conn.queue_recv(fs_bytes);
-        executor
-            .negotiations
-            .insert(ChannelId::new([0xbb; 32]), sample_funding_negotiation());
+        executor.negotiations.insert(
+            TemporaryChannelId::new([0xbb; 32]),
+            sample_funding_negotiation(),
+        );
         let err = executor
             .execute(
                 &Program {
@@ -3825,9 +3831,10 @@ mod tests {
         .encode();
         let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
         executor.conn.queue_recv(fs_bytes);
-        executor
-            .negotiations
-            .insert(ChannelId::new([0xbb; 32]), sample_funding_negotiation());
+        executor.negotiations.insert(
+            TemporaryChannelId::new([0xbb; 32]),
+            sample_funding_negotiation(),
+        );
         executor
             .execute(&program, std::time::Instant::now())
             .unwrap();
@@ -3989,9 +3996,10 @@ mod tests {
         let mut executor = Executor::new(MockConnection::new(), mock_cli, sample_context());
         executor.conn.queue_recv(fs_bytes);
         executor.conn.queue_recv(cr_bytes);
-        executor
-            .negotiations
-            .insert(ChannelId::new([0xbb; 32]), sample_funding_negotiation());
+        executor.negotiations.insert(
+            TemporaryChannelId::new([0xbb; 32]),
+            sample_funding_negotiation(),
+        );
 
         (executor, channel_id, target_pcp)
     }
@@ -4005,7 +4013,7 @@ mod tests {
         // marking the funding outpoint invalid.
         executor
             .negotiations
-            .get_mut(&ChannelId::new([0xbb; 32]))
+            .get_mut(&TemporaryChannelId::new([0xbb; 32]))
             .unwrap()
             .open_channel
             .funding_pubkey = sample_pubkey(1);
@@ -4222,7 +4230,7 @@ mod tests {
         let ac = sample_accept_channel();
         assert_eq!(
             extract_field(&ac, AcceptChannelField::TemporaryChannelId),
-            Variable::ChannelId(ChannelId::new([0xbb; 32]))
+            Variable::ChannelId(TemporaryChannelId::new([0xbb; 32]))
         );
     }
 

--- a/smite/src/bolt.rs
+++ b/smite/src/bolt.rs
@@ -76,7 +76,7 @@ pub use tx_remove_output::TxRemoveOutput;
 pub use types::{
     BigSize, CHANNEL_ID_SIZE, COMPACT_SIGNATURE_SIZE, ChannelId, MAX_MESSAGE_SIZE,
     PAYMENT_ONION_PACKET_SIZE, PER_COMMITMENT_SECRET_SIZE, PUBLIC_KEY_SIZE, SHA256_HASH_SIZE,
-    SHORT_CHANNEL_ID_SIZE, ShortChannelId, TXID_SIZE, Tu32, Tu64,
+    SHORT_CHANNEL_ID_SIZE, ShortChannelId, TXID_SIZE, TemporaryChannelId, Tu32, Tu64,
 };
 pub use update_add_htlc::{UpdateAddHtlc, UpdateAddHtlcTlvs};
 pub use update_fail_htlc::{UpdateFailHtlc, UpdateFailHtlcTlvs};
@@ -605,7 +605,7 @@ mod tests {
 
         OpenChannel {
             chain_hash: [0xaa; CHAIN_HASH_SIZE],
-            temporary_channel_id: ChannelId::new([0xbb; 32]),
+            temporary_channel_id: TemporaryChannelId::new([0xbb; 32]),
             funding_satoshis: 100_000,
             push_msat: 0,
             dust_limit_satoshis: 546,
@@ -642,7 +642,7 @@ mod tests {
         let pk = PublicKey::from_secret_key(&secp, &sk);
 
         AcceptChannel {
-            temporary_channel_id: ChannelId::new([0xbb; 32]),
+            temporary_channel_id: TemporaryChannelId::new([0xbb; 32]),
             dust_limit_satoshis: 546,
             max_htlc_value_in_flight_msat: 100_000_000,
             channel_reserve_satoshis: 10_000,
@@ -677,7 +677,7 @@ mod tests {
         let sig = secp.sign_ecdsa(&msg, &sk);
 
         FundingCreated {
-            temporary_channel_id: ChannelId::new([0xbb; CHANNEL_ID_SIZE]),
+            temporary_channel_id: TemporaryChannelId::new([0xbb; CHANNEL_ID_SIZE]),
             funding_txid: Txid::from_byte_array([0xcc; TXID_SIZE]),
             funding_output_index: 0,
             signature: sig,
@@ -805,7 +805,7 @@ mod tests {
 
         OpenChannel2 {
             chain_hash: [0xaa; CHAIN_HASH_SIZE],
-            temporary_channel_id: ChannelId::new([0xbb; 32]),
+            temporary_channel_id: TemporaryChannelId::new([0xbb; 32]),
             funding_feerate_perkw: 2_500,
             commitment_feerate_perkw: 253,
             funding_satoshis: 100_000,
@@ -851,7 +851,7 @@ mod tests {
             .collect();
 
         AcceptChannel2 {
-            temporary_channel_id: ChannelId::new([0xbb; CHANNEL_ID_SIZE]),
+            temporary_channel_id: TemporaryChannelId::new([0xbb; CHANNEL_ID_SIZE]),
             funding_satoshis: 50_000,
             dust_limit_satoshis: 546,
             max_htlc_value_in_flight_msat: 100_000_000,

--- a/smite/src/bolt/accept_channel.rs
+++ b/smite/src/bolt/accept_channel.rs
@@ -2,7 +2,7 @@
 
 use super::BoltError;
 use super::tlv::TlvStream;
-use super::types::ChannelId;
+use super::types::TemporaryChannelId;
 use super::wire::WireFormat;
 use bitcoin::secp256k1::PublicKey;
 
@@ -19,7 +19,7 @@ const TLV_CHANNEL_TYPE: u64 = 1;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AcceptChannel {
     /// The same temporary channel ID received from the initiator's `open_channel` message.
-    pub temporary_channel_id: ChannelId,
+    pub temporary_channel_id: TemporaryChannelId,
     /// The threshold below which outputs on transactions broadcast by the channel acceptor will be omitted
     pub dust_limit_satoshis: u64,
     /// The maximum total value of inbound HTLCs in flight toward the channel acceptor, in millisatoshis
@@ -176,7 +176,7 @@ mod tests {
             .collect();
 
         AcceptChannel {
-            temporary_channel_id: ChannelId::new([0xbb; 32]),
+            temporary_channel_id: TemporaryChannelId::new([0xbb; 32]),
             dust_limit_satoshis: 546,
             max_htlc_value_in_flight_msat: 100_000_000,
             channel_reserve_satoshis: 10_000,

--- a/smite/src/bolt/accept_channel2.rs
+++ b/smite/src/bolt/accept_channel2.rs
@@ -2,7 +2,7 @@
 
 use super::BoltError;
 use super::tlv::TlvStream;
-use super::types::ChannelId;
+use super::types::TemporaryChannelId;
 use super::wire::{EmptyTlv, WireFormat};
 use bitcoin::secp256k1::PublicKey;
 
@@ -22,7 +22,7 @@ const TLV_REQUIRE_CONFIRMED_INPUTS: u64 = 2;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AcceptChannel2 {
     /// The same temporary channel ID received from the initiator's `open_channel2` message
-    pub temporary_channel_id: ChannelId,
+    pub temporary_channel_id: TemporaryChannelId,
     /// The amount the channel acceptor contributes to the channel, in satoshis
     pub funding_satoshis: u64,
     /// The threshold below which outputs on transactions broadcast by the channel acceptor will be omitted
@@ -205,7 +205,7 @@ mod tests {
             .collect();
 
         AcceptChannel2 {
-            temporary_channel_id: ChannelId::new([0xbb; CHANNEL_ID_SIZE]),
+            temporary_channel_id: TemporaryChannelId::new([0xbb; CHANNEL_ID_SIZE]),
             funding_satoshis: 100_000,
             dust_limit_satoshis: 546,
             max_htlc_value_in_flight_msat: 100_000_000,

--- a/smite/src/bolt/funding_created.rs
+++ b/smite/src/bolt/funding_created.rs
@@ -1,7 +1,7 @@
 //! BOLT 2 funding created message.
 
 use super::BoltError;
-use super::types::ChannelId;
+use super::types::TemporaryChannelId;
 use super::wire::WireFormat;
 use bitcoin::Txid;
 use bitcoin::secp256k1::ecdsa::Signature;
@@ -14,7 +14,7 @@ use bitcoin::secp256k1::ecdsa::Signature;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FundingCreated {
     /// A temporary channel ID used until the funding outpoint is announced
-    pub temporary_channel_id: ChannelId,
+    pub temporary_channel_id: TemporaryChannelId,
     /// The transaction ID of the funding transaction
     pub funding_txid: Txid,
     /// The specific output index funding this channel
@@ -73,7 +73,7 @@ mod tests {
         let sig = secp.sign_ecdsa(&msg, &sk);
 
         FundingCreated {
-            temporary_channel_id: ChannelId::new([0xbb; CHANNEL_ID_SIZE]),
+            temporary_channel_id: TemporaryChannelId::new([0xbb; CHANNEL_ID_SIZE]),
             funding_txid: Txid::from_byte_array([0xcc; TXID_SIZE]),
             funding_output_index: 0,
             signature: sig,

--- a/smite/src/bolt/open_channel.rs
+++ b/smite/src/bolt/open_channel.rs
@@ -2,7 +2,7 @@
 
 use super::BoltError;
 use super::tlv::TlvStream;
-use super::types::{CHAIN_HASH_SIZE, ChannelId};
+use super::types::{CHAIN_HASH_SIZE, TemporaryChannelId};
 use super::wire::WireFormat;
 use bitcoin::secp256k1::PublicKey;
 
@@ -20,7 +20,7 @@ pub struct OpenChannel {
     /// The genesis hash of the blockchain on which the channel is to be opened
     pub chain_hash: [u8; CHAIN_HASH_SIZE],
     /// A temporary channel ID used until the funding outpoint is announced
-    pub temporary_channel_id: ChannelId,
+    pub temporary_channel_id: TemporaryChannelId,
     /// The amount the channel initiator contributes to the channel, in satoshis
     pub funding_satoshis: u64,
     /// The amount the channel initiator unconditionally gives to the counterparty, in millisatoshis
@@ -196,7 +196,7 @@ mod tests {
 
         OpenChannel {
             chain_hash: [0xaa; CHAIN_HASH_SIZE],
-            temporary_channel_id: ChannelId::new([0xbb; 32]),
+            temporary_channel_id: TemporaryChannelId::new([0xbb; 32]),
             funding_satoshis: 100_000,
             push_msat: 0,
             dust_limit_satoshis: 546,

--- a/smite/src/bolt/open_channel2.rs
+++ b/smite/src/bolt/open_channel2.rs
@@ -2,7 +2,7 @@
 
 use super::BoltError;
 use super::tlv::TlvStream;
-use super::types::{CHAIN_HASH_SIZE, ChannelId};
+use super::types::{CHAIN_HASH_SIZE, TemporaryChannelId};
 use super::wire::{EmptyTlv, WireFormat};
 use bitcoin::secp256k1::PublicKey;
 
@@ -24,7 +24,7 @@ pub struct OpenChannel2 {
     /// The genesis hash of the blockchain on which the channel is to be opened
     pub chain_hash: [u8; CHAIN_HASH_SIZE],
     /// A temporary channel ID used until the funding outpoint is announced
-    pub temporary_channel_id: ChannelId,
+    pub temporary_channel_id: TemporaryChannelId,
     /// The feerate for the funding transaction, in satoshis per 1000 weight units
     pub funding_feerate_perkw: u32,
     /// The feerate for commitment transactions, in satoshis per 1000 weight units
@@ -221,7 +221,7 @@ mod tests {
 
         OpenChannel2 {
             chain_hash: [0xaa; CHAIN_HASH_SIZE],
-            temporary_channel_id: ChannelId::new([0xbb; 32]),
+            temporary_channel_id: TemporaryChannelId::new([0xbb; 32]),
             funding_feerate_perkw: 2_500,
             commitment_feerate_perkw: 253,
             funding_satoshis: 100_000,

--- a/smite/src/bolt/types.rs
+++ b/smite/src/bolt/types.rs
@@ -39,6 +39,13 @@ pub const PER_COMMITMENT_SECRET_SIZE: usize = 32;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
 pub struct ChannelId(pub [u8; CHANNEL_ID_SIZE]);
 
+/// A `temporary_channel_id`: the id a channel is known by from `open_channel`
+/// until the real `channel_id` exists.
+///
+/// Same wire type as [`ChannelId`], so this only documents which of the two
+/// ids a value is.
+pub type TemporaryChannelId = ChannelId;
+
 impl ChannelId {
     /// Special all-zero channel ID indicating "all channels" (for errors)
     /// or "not channel-specific" (for warnings).

--- a/smite/src/oracles/accept_channel.rs
+++ b/smite/src/oracles/accept_channel.rs
@@ -272,7 +272,7 @@ fn verify_initial_commitment(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bolt::{AcceptChannelTlvs, ChannelId, OpenChannelTlvs};
+    use crate::bolt::{AcceptChannelTlvs, OpenChannelTlvs, TemporaryChannelId};
     use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 
     fn pubkey(seed: u8) -> PublicKey {
@@ -285,7 +285,7 @@ mod tests {
         let key = pubkey(1);
         OpenChannel {
             chain_hash: [0u8; 32],
-            temporary_channel_id: ChannelId::new([1u8; 32]),
+            temporary_channel_id: TemporaryChannelId::new([1u8; 32]),
             funding_satoshis: 10_000_000,
             push_msat: 3_000_000_000,
             dust_limit_satoshis: 546,
@@ -313,7 +313,7 @@ mod tests {
     fn accept_channel() -> AcceptChannel {
         let key = pubkey(2);
         AcceptChannel {
-            temporary_channel_id: ChannelId::new([1u8; 32]),
+            temporary_channel_id: TemporaryChannelId::new([1u8; 32]),
             dust_limit_satoshis: 546,
             max_htlc_value_in_flight_msat: 100_000_000,
             channel_reserve_satoshis: 10_000,

--- a/smite/src/violation.rs
+++ b/smite/src/violation.rs
@@ -8,7 +8,7 @@
 //! never a `Violation` (e.g., transport failures, insufficient wallet funds,
 //! mutator-produced invalid commitments, undecodable harness input).
 
-use crate::bolt::ChannelId;
+use crate::bolt::{ChannelId, TemporaryChannelId};
 
 /// A detected misbehavior of the target under test.
 #[derive(Debug, thiserror::Error)]
@@ -34,7 +34,7 @@ pub enum Violation {
     /// - its own fields breach the `accept_channel` requirements, or
     /// - it reuses a `temporary_channel_id` still awaiting `funding_created`.
     #[error("invalid accept_channel for temporary_channel_id {0}: {1}")]
-    InvalidAcceptChannel(ChannelId, String),
+    InvalidAcceptChannel(TemporaryChannelId, String),
 
     /// The target sent a `funding_signed` or `channel_ready` for a `channel_id`
     /// we never opened, i.e. one for which no state was ever established.


### PR DESCRIPTION
`open_channel` and its replies carry a `temporary_channel_id` that is a plain `ChannelId` on the wire, so every field and map keyed by it read as just another channel id. In particular, a signature such as `HashMap<ChannelId, PendingChannel>` did not say which of the two ids it was keyed by.

Add `TemporaryChannelId` as an alias rather than a newtype: the wire format is identical and the compiler still treats both as one type, so this only documents which id a value holds, at no cost to the callers.