### PR TITLE
smite-scenarios: log warning and tx_abort data on receive

### DIFF
--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -1246,6 +1246,24 @@ fn recv_non_ping(conn: &mut impl Connection, timeout: Duration) -> Result<Messag
             }
             // Surface the received error message.
             Message::Error(e) => return Err(ExecuteError::PeerError(e)),
+            // Log the human-readable data before handing the message to the
+            // caller, which typically only inspects the message type.
+            Message::Warning(ref w) => {
+                log::debug!(
+                    "received warning on {}: {}",
+                    w.channel_id,
+                    String::from_utf8_lossy(&w.data)
+                );
+                return Ok(msg);
+            }
+            Message::TxAbort(ref a) => {
+                log::debug!(
+                    "received tx_abort on {}: {}",
+                    a.channel_id,
+                    String::from_utf8_lossy(&a.data)
+                );
+                return Ok(msg);
+            }
             other => return Ok(other),
         }
     })();


### PR DESCRIPTION
`warning` and `tx_abort` are, with `error`, the only wire messages that carry a human-readable `data` field. `recv_non_ping` already surfaces `error` through `ExecuteError::PeerError`, but a `warning` or `tx_abort` was handed back to the caller as-is, and callers only inspect the message type, so the text the target sent was lost.

Log the channel id and data at warn level before returning the message. The bytes are printed with a lossy UTF-8 conversion rather than filtered to printable ASCII: targets are cooperating implementations under test, so readability is the only concern.