### PR TITLE
clippy: ignore conditional drop-non-drop error

### DIFF
--- a/smite/src/scenarios.rs
+++ b/smite/src/scenarios.rs
@@ -164,6 +164,7 @@ pub fn smite_run<S: Scenario>() -> std::process::ExitCode {
     // Drop runner before scenario. This provides a huge speedup in Nyx
     // mode since nyx_release() resets the VM before scenario cleanup
     // ever runs.
+    #[allow(clippy::drop_non_drop)]
     drop(runner);
 
     ExitCode::SUCCESS


### PR DESCRIPTION
Without this commit, `clippy` without any flags fails:

```
error: call to `std::mem::drop` with a value that does not implement `Drop`. Dropping such a type only extends its contained lifetimes
   --> smite/src/scenarios.rs:167:5
    |
167 |     drop(runner);
    |     ^^^^^^^^^^^^
    |
note: argument has type `runners::StdRunner`
   --> smite/src/scenarios.rs:167:10
    |
167 |     drop(runner);
    |          ^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#drop_non_drop
    = note: `-D clippy::drop-non-drop` implied by `-D clippy::all`
    = help: to override `-D clippy::all` add `#[allow(clippy::drop_non_drop)]`

error: could not compile `smite` (lib) due to 1 previous error
```

This is the case because only `NyxRunner` implements `Drop`, so with `--all-features`, there's no error with clippy.

This is confusing Claude, and I think this would confuse new people, too. When you run `cargo clippy` and you get an error, it looks unintentional like a bug.