### PR TITLE
smitebot: print crash reports for bench-exec

### DIFF
--- a/smitebot/src/commands/bench_exec.rs
+++ b/smitebot/src/commands/bench_exec.rs
@@ -11,6 +11,7 @@
 //! already-prepared sharedir (e.g. from a prior `start`, `bench-exec`, or
 //! `scripts/setup-nyx.sh`).
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -20,7 +21,7 @@ use clap::Args;
 use crate::commands::build::{BuildInputs, run_build};
 use crate::config::CampaignConfig;
 use crate::latency_stats::{LatencyStats, avg_duration, mean_stddev};
-use crate::libnyx::{Libnyx, PAYLOAD_HEADER_SIZE};
+use crate::libnyx::{Libnyx, NyxReturn, PAYLOAD_HEADER_SIZE};
 use crate::utils::{pin_to_cpu, setup_nyx};
 
 /// Default number of timed executions when `--iterations` is not given.
@@ -251,6 +252,7 @@ fn run_once(
     let mut target_runtimes = Vec::with_capacity(iterations);
     let mut overheads = Vec::with_capacity(iterations);
     let mut failed_iterations = 0u64;
+    let mut crash_reports: HashMap<String, u64> = HashMap::new();
     let mut dirty_pages_total = 0u64;
     // Throughput is the sum of the timed exec latencies, not the loop's wall
     // clock.
@@ -270,6 +272,16 @@ fn run_once(
         dirty_pages_total += u64::from(stats.dirty_pages);
         if !stats.result.is_normal() {
             failed_iterations += 1;
+            // The crash buffer is written for these outcomes and never cleared,
+            // so we only check the buffer when it changes.
+            let report = match stats.result {
+                NyxReturn::Crash | NyxReturn::Abort | NyxReturn::InvalidWriteToPayload => {
+                    vm.crash_report()
+                }
+                _ => None,
+            };
+            let report = report.unwrap_or_else(|| format!("{:?} (no crash report)", stats.result));
+            *crash_reports.entry(report).or_insert(0) += 1;
         }
 
         if let Some(tracker) = coverage.as_mut() {
@@ -288,6 +300,7 @@ fn run_once(
         target: LatencyStats::summarize(&mut target_runtimes),
         overhead: LatencyStats::summarize(&mut overheads),
         coverage: coverage.map(|c| c.summary()),
+        crash_reports,
     })
 }
 
@@ -564,6 +577,8 @@ struct RunResult {
     overhead: LatencyStats,
     /// Edge-coverage stability across the run, if a bitmap was available.
     coverage: Option<CoverageSummary>,
+    /// Crash reports encountered and counts of occurrences.
+    crash_reports: HashMap<String, u64>,
 }
 
 impl RunResult {
@@ -645,6 +660,7 @@ impl BenchReport {
             "    failed iterations: {} / {}",
             run.failed_iterations, self.iterations
         );
+        print_crash_reports(&run.crash_reports);
         if let Some(cov) = &run.coverage {
             println!(
                 "    coverage determinism: {:.1}% stable ({} / {} edges fluctuated)",
@@ -698,6 +714,14 @@ impl BenchReport {
         );
         println!("    failed iterations: {total_failed_iterations} / {total_execs}");
 
+        // Pool the per-run tallies so a report that appears in several runs is
+        // counted once, with its total.
+        let mut pooled_reports: HashMap<String, u64> = HashMap::new();
+        for (report, count) in self.runs.iter().flat_map(|r| &r.crash_reports) {
+            *pooled_reports.entry(report.clone()).or_insert(0) += count;
+        }
+        print_crash_reports(&pooled_reports);
+
         // Each run measures its own snapshot's determinism; summing the counts
         // over runs gives a pooled stable percentage (an edge stable in every
         // run of every boot). Skip if no run produced a bitmap.
@@ -714,6 +738,14 @@ impl BenchReport {
                 pooled.executed_edges,
             );
         }
+    }
+}
+
+/// Prints each distinct crash report and how many executions hit it. Prints
+/// nothing when no execution failed.
+fn print_crash_reports(reports: &HashMap<String, u64>) {
+    for (report, count) in reports {
+        println!("    [{count}x] {}", report.replace('\n', "\n      "));
     }
 }
 

--- a/smitebot/src/libnyx.rs
+++ b/smitebot/src/libnyx.rs
@@ -103,6 +103,7 @@ type OptionApply = unsafe extern "C" fn(*mut c_void);
 type SetInput = unsafe extern "C" fn(*mut c_void, *mut u8, u32);
 type Exec = unsafe extern "C" fn(*mut c_void) -> i32;
 type GetAuxBuffer = unsafe extern "C" fn(*mut c_void) -> *mut u8;
+type GetAuxString = unsafe extern "C" fn(*mut c_void, *mut u8, u32) -> u32;
 type GetBitmapBuffer = unsafe extern "C" fn(*mut c_void) -> *mut u8;
 type GetBitmapBufferSize = unsafe extern "C" fn(*mut c_void) -> usize;
 type Shutdown = unsafe extern "C" fn(*mut c_void);
@@ -127,6 +128,7 @@ pub struct Libnyx {
     set_afl_input: SetInput,
     exec: Exec,
     get_aux_buffer: GetAuxBuffer,
+    get_aux_string: GetAuxString,
     get_bitmap_buffer: GetBitmapBuffer,
     get_bitmap_buffer_size: GetBitmapBufferSize,
     shutdown: Shutdown,
@@ -234,6 +236,7 @@ impl Libnyx {
                 set_afl_input: sym(handle, c"nyx_set_afl_input")?,
                 exec: sym(handle, c"nyx_exec")?,
                 get_aux_buffer: sym(handle, c"nyx_get_aux_buffer")?,
+                get_aux_string: sym(handle, c"nyx_get_aux_string")?,
                 get_bitmap_buffer: sym(handle, c"nyx_get_bitmap_buffer")?,
                 get_bitmap_buffer_size: sym(handle, c"nyx_get_bitmap_buffer_size")?,
                 shutdown: sym(handle, c"nyx_shutdown")?,
@@ -394,6 +397,32 @@ impl NyxVm<'_> {
             target_runtime,
             dirty_pages,
         }
+    }
+
+    /// Returns the crash report for the execution that just ran, or `None` if
+    /// there is none. May return a previous execution's crash report if the
+    /// latest execution did not crash.
+    ///
+    /// This is the same text AFL++ saves to the `.log` file beside a crashing
+    /// input.
+    #[must_use]
+    pub fn crash_report(&self) -> Option<String> {
+        const AUX_STRING_CAPACITY: usize = 4096;
+        let mut buf = vec![0u8; AUX_STRING_CAPACITY];
+        // SAFETY: `buf` is a live allocation of exactly the length passed.
+        let len = unsafe {
+            (self.lib.get_aux_string)(
+                self.process,
+                buf.as_mut_ptr(),
+                u32::try_from(buf.len()).expect("capacity fits in u32"),
+            )
+        } as usize;
+        buf.truncate(len.min(AUX_STRING_CAPACITY));
+        let report = String::from_utf8_lossy(&buf).trim_end().to_string();
+        if report.is_empty() {
+            return None;
+        }
+        Some(report)
     }
 
     /// Asserts that the auxiliary buffer has the magic, version, and hash this binding's


### PR DESCRIPTION
For all crashes encountered during benchmarking, print the crash logs recorded by Nyx.  This is helpful for debugging flaky crashes in Nyx mode.

In particular, this helped me debug https://github.com/lnfuzz/smite/issues/237.

Sample output:

```
Smite Nyx benchmark
  target:      ldk/ir
  sharedir:    /tmp/smite-ldk
  input size:  2873 bytes
  input buffer:1048576 bytes
  iterations:  200
  repeats:     2

  run 1/2:
  boot + snapshot creation: 4.416 s
  steady-state (snapshot restore + target run):
    execs/sec: 4.6
    exec time: 43.535 s
    latency:   min 201.67 ms  mean 217.67 ms  median 216.20 ms  p99 240.67 ms  max 253.51 ms
    input execution: mean 215.32 ms  median 213.91 ms   (guest runtime)
    nyx overhead:    mean 2.36 ms  median 2.33 ms   (restore + reset + ipc; 2994 dirty pages/exec)
    failed iterations: 168 / 200
    [168x] panicked at smite/src/bitcoin.rs:157:9:
      bitcoin-cli generateblock failed: error code: -5
      error message:
      Transaction 769b8b38579013c530760c407e5a34978d072cf9148a95c200733d990b239f41 not in mempool.
    coverage determinism: 65.5% stable (9327 / 27073 edges fluctuated)

  run 2/2:
  boot + snapshot creation: 4.110 s
  steady-state (snapshot restore + target run):
    execs/sec: 4.5
    exec time: 44.873 s
    latency:   min 141.89 ms  mean 224.37 ms  median 226.24 ms  p99 250.66 ms  max 270.24 ms
    input execution: mean 222.04 ms  median 223.98 ms   (guest runtime)
    nyx overhead:    mean 2.33 ms  median 2.29 ms   (restore + reset + ipc; 3082 dirty pages/exec)
    failed iterations: 3 / 200
    [3x] panicked at smite/src/bitcoin.rs:157:9:
      bitcoin-cli generateblock failed: error code: -5
      error message:
      Transaction dbce6dd8c04757030829b1a8449c6141b0ca3ff0df4a7d0561795648aa5d10ae not in mempool.
    coverage determinism: 65.3% stable (9497 / 27343 edges fluctuated)

  aggregate over 2 runs:
    execs/sec: mean 4.5  stddev 0.1  min 4.5  max 4.6
    boot + snapshot: mean 4.263 s
    latency (mean across runs):
      min 171.78 ms  mean 221.02 ms  median 221.22 ms  p99 245.67 ms  max 261.88 ms
    input execution (mean across runs): mean 218.68 ms  median 218.95 ms
    nyx overhead (mean across runs):     mean 2.35 ms  median 2.31 ms
    failed iterations: 171 / 400
    [168x] panicked at smite/src/bitcoin.rs:157:9:
      bitcoin-cli generateblock failed: error code: -5
      error message:
      Transaction 769b8b38579013c530760c407e5a34978d072cf9148a95c200733d990b239f41 not in mempool.
    [3x] panicked at smite/src/bitcoin.rs:157:9:
      bitcoin-cli generateblock failed: error code: -5
      error message:
      Transaction dbce6dd8c04757030829b1a8449c6141b0ca3ff0df4a7d0561795648aa5d10ae not in mempool.
    coverage determinism: 65.4% stable (18824 / 54416 edges fluctuated, summed over runs)
```