### PR TITLE
smite-scenarios: suppress known oracle violations

### DIFF
--- a/smite-scenarios/src/targets/cln.rs
+++ b/smite-scenarios/src/targets/cln.rs
@@ -373,6 +373,17 @@ impl Target for ClnTarget {
     ///   `open_channel` negotiation. These values should be rejected early, as
     ///   required by BOLT 2.
     ///   See: <https://github.com/ElementsProject/lightning/issues/9403>
+    ///
+    /// - CLN currently allows both initial commitment balances to be at or
+    ///   below `channel_reserve_satoshis` during `open_channel` negotiation.
+    ///   These values should be rejected early, as required by BOLT 2.
+    ///   See: <https://github.com/ElementsProject/lightning/issues/9475>
+    ///
+    /// - CLN currently allows the funder to push out too much funds during
+    ///   `open_channel` negotiation, not leaving enough to pay the commitment
+    ///   fee or fund the anchor outputs. This situation should be rejected
+    ///   early, as required by BOLT 2.
+    ///   See: <https://github.com/ElementsProject/lightning/issues/9491>
     fn known_violations() -> &'static [&'static [&'static str]] {
         &[
             &[
@@ -382,6 +393,16 @@ impl Target for ClnTarget {
             &[
                 "accepted invalid open_channel: dust_limit_satoshis",
                 "is below the minimum of 354 sat",
+            ],
+            &["accepted invalid open_channel: neither side exceeds channel reserve"],
+            &["invalid accept_channel: neither side exceeds channel reserve"],
+            &[
+                "accepted invalid open_channel: opener balance",
+                "sat cannot cover the commitment fee of",
+            ],
+            &[
+                "accepted invalid open_channel: opener balance",
+                "sat cannot cover anchor cost of",
             ],
         ]
     }

--- a/smite-scenarios/src/targets/ldk.rs
+++ b/smite-scenarios/src/targets/ldk.rs
@@ -203,4 +203,16 @@ impl Target for LdkTarget {
         }
         Ok(())
     }
+
+    /// Known violations suppressed until fixed upstream:
+    ///
+    /// - LDK doesn't fail the channel when both initial commitment balances are
+    ///   at or below `channel_reserve_satoshis`, as BOLT 2 requires.
+    ///   See: <https://git.rust-bitcoin.org/lightningdevkit/rust-lightning/issues/4931>
+    fn known_violations() -> &'static [&'static [&'static str]] {
+        &[
+            &["accepted invalid open_channel: neither side exceeds channel reserve"],
+            &["invalid accept_channel: neither side exceeds channel reserve"],
+        ]
+    }
 }

--- a/smite-scenarios/src/targets/lnd.rs
+++ b/smite-scenarios/src/targets/lnd.rs
@@ -337,7 +337,25 @@ impl Target for LndTarget {
     /// - LND allows `open_channel` with an omitted `channel_type`, violating
     ///   BOLT 2 even though it signals the required `option_channel_type` feature.
     ///   See: <https://github.com/lightningnetwork/lnd/pull/11064>
+    ///
+    /// - LND doesn't fail the channel when both initial commitment balances are
+    ///   at or below `channel_reserve_satoshis`, as BOLT 2 requires.
+    ///   See: <https://github.com/lightningnetwork/lnd/issues/11149>
+    ///
+    /// - LND accepts `push_msat` above the channel capacity, which BOLT 2
+    ///   requires it to reject. Its only bound is a fundee balance computed on
+    ///   a wrapping `uint64` and then tested as an `int64`, so any push above
+    ///   roughly 2^63 wraps back into the non-negative range.
+    ///   See: <https://github.com/lightningnetwork/lnd/pull/10765>
     fn known_violations() -> &'static [&'static [&'static str]] {
-        &[&["accepted invalid open_channel: open_channel does not include a channel_type"]]
+        &[
+            &["accepted invalid open_channel: open_channel does not include a channel_type"],
+            &["accepted invalid open_channel: neither side exceeds channel reserve"],
+            &["invalid accept_channel: neither side exceeds channel reserve"],
+            &[
+                "accepted invalid open_channel: push_msat",
+                "exceeds funding amount",
+            ],
+        ]
     }
 }


### PR DESCRIPTION
I went through all the known issues and added suppressions for those that won't be fixed after bumping the target versions in #241.