### PR TITLE
bolt: add stfu message codec

### DIFF
--- a/smite/src/bolt.rs
+++ b/smite/src/bolt.rs
@@ -26,6 +26,7 @@ mod ping;
 mod pong;
 mod revoke_and_ack;
 mod shutdown;
+mod stfu;
 mod tlv;
 mod tx_abort;
 mod tx_ack_rbf;
@@ -65,6 +66,7 @@ pub use ping::Ping;
 pub use pong::Pong;
 pub use revoke_and_ack::RevokeAndAck;
 pub use shutdown::{Shutdown, is_acceptable_shutdown_script, is_standard_shutdown_script};
+pub use stfu::Stfu;
 pub use tlv::{TlvRecord, TlvStream};
 pub use tx_abort::TxAbort;
 pub use tx_ack_rbf::{TxAckRbf, TxAckRbfTlvs};
@@ -146,6 +148,8 @@ pub struct MessageType(u16);
 impl MessageType {
     /// Warning message (BOLT 1).
     pub const WARNING: MessageType = MessageType(1);
+    /// `stfu` message (BOLT 2).
+    pub const STFU: MessageType = MessageType(2);
     /// Init message (BOLT 1).
     pub const INIT: MessageType = MessageType(16);
     /// Error message (BOLT 1).
@@ -229,6 +233,7 @@ impl MessageType {
     pub fn name(self) -> &'static str {
         match self {
             Self::WARNING => "warning",
+            Self::STFU => "stfu",
             Self::INIT => "init",
             Self::ERROR => "error",
             Self::PING => "ping",
@@ -278,6 +283,8 @@ impl std::fmt::Display for MessageType {
 pub enum Message {
     /// Warning message (type 1).
     Warning(Warning),
+    /// `stfu` message (type 2).
+    Stfu(Stfu),
     /// Init message (type 16).
     Init(Init),
     /// Error message (type 17).
@@ -366,6 +373,7 @@ impl Message {
     pub fn msg_type(&self) -> MessageType {
         match self {
             Self::Warning(_) => MessageType::WARNING,
+            Self::Stfu(_) => MessageType::STFU,
             Self::Init(_) => MessageType::INIT,
             Self::Error(_) => MessageType::ERROR,
             Self::Ping(_) => MessageType::PING,
@@ -409,6 +417,7 @@ impl Message {
         self.msg_type().as_u16().write(&mut out);
         match self {
             Self::Warning(m) => out.extend(m.encode()),
+            Self::Stfu(m) => out.extend(m.encode()),
             Self::Init(m) => out.extend(m.encode()),
             Self::Error(m) => out.extend(m.encode()),
             Self::Ping(m) => out.extend(m.encode()),
@@ -459,6 +468,7 @@ impl Message {
 
         match MessageType::from_u16(msg_type) {
             MessageType::WARNING => Ok(Self::Warning(Warning::decode(cursor)?)),
+            MessageType::STFU => Ok(Self::Stfu(Stfu::decode(cursor)?)),
             MessageType::INIT => Ok(Self::Init(Init::decode(cursor)?)),
             MessageType::ERROR => Ok(Self::Error(Error::decode(cursor)?)),
             MessageType::PING => Ok(Self::Ping(Ping::decode(cursor)?)),
@@ -551,7 +561,7 @@ mod tests {
     use bitcoin::secp256k1::{self, PublicKey, Secp256k1, SecretKey};
     use types::CHAIN_HASH_SIZE;
 
-    // Tests ordered by message type number: Warning(1), Init(16), Error(17), Ping(18), Pong(19)
+    // Tests ordered by message type number: Warning(1), Stfu(2), Init(16), Error(17), Ping(18), Pong(19)
 
     #[test]
     fn message_warning_roundtrip() {
@@ -560,6 +570,18 @@ mod tests {
         let encoded = msg.encode();
         let decoded = Message::decode(&encoded).unwrap();
         assert_eq!(decoded, Message::Warning(warning));
+    }
+
+    #[test]
+    fn message_stfu_roundtrip() {
+        let stfu = Stfu {
+            channel_id: ChannelId::new([0xab; CHANNEL_ID_SIZE]),
+            initiator: 1,
+        };
+        let msg = Message::Stfu(stfu.clone());
+        let encoded = msg.encode();
+        let decoded = Message::decode(&encoded).unwrap();
+        assert_eq!(decoded, Message::Stfu(stfu));
     }
 
     #[test]
@@ -1225,6 +1247,14 @@ mod tests {
                 Message::Warning(Warning::all_channels("")),
                 "warning",
                 MessageType::WARNING,
+            ),
+            (
+                Message::Stfu(Stfu {
+                    channel_id: ChannelId::new([0; CHANNEL_ID_SIZE]),
+                    initiator: 0,
+                }),
+                "stfu",
+                MessageType::STFU,
             ),
             (Message::Init(Init::empty()), "init", MessageType::INIT),
             (

--- a/smite/src/bolt/stfu.rs
+++ b/smite/src/bolt/stfu.rs
@@ -1,0 +1,116 @@
+//! BOLT 2 `stfu` message.
+
+use super::BoltError;
+use super::types::ChannelId;
+use super::wire::WireFormat;
+
+/// BOLT 2 `stfu` message (type 2).
+///
+/// Sent by either peer to quiesce a channel before a protocol that requires
+/// no pending updates.  Requires `option_quiesce`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Stfu {
+    /// The channel to quiesce.
+    pub channel_id: ChannelId,
+    /// 1 when initiating quiescence, 0 when replying to a peer's `stfu`.
+    pub initiator: u8,
+}
+
+impl Stfu {
+    /// Encodes to wire format (without message type prefix).
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        self.channel_id.write(&mut out);
+        self.initiator.write(&mut out);
+        out
+    }
+
+    /// Decodes from wire format (without message type prefix).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Truncated` if the payload is too short.
+    pub fn decode(payload: &[u8]) -> Result<Self, BoltError> {
+        let mut cursor = payload;
+        let channel_id = ChannelId::read(&mut cursor)?;
+        let initiator = u8::read(&mut cursor)?;
+
+        Ok(Self {
+            channel_id,
+            initiator,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::CHANNEL_ID_SIZE;
+    use super::*;
+
+    #[test]
+    fn encode_fixed_field_size() {
+        let msg = Stfu {
+            channel_id: ChannelId::new([0x42; CHANNEL_ID_SIZE]),
+            initiator: 1,
+        };
+        let encoded = msg.encode();
+        assert_eq!(encoded.len(), CHANNEL_ID_SIZE + 1);
+        assert_eq!(encoded[CHANNEL_ID_SIZE], 1);
+    }
+
+    #[test]
+    fn roundtrip() {
+        for initiator in [0, 1, 0xff] {
+            let original = Stfu {
+                channel_id: ChannelId::new([0xab; CHANNEL_ID_SIZE]),
+                initiator,
+            };
+            let encoded = original.encode();
+            let decoded = Stfu::decode(&encoded).unwrap();
+            assert_eq!(original, decoded);
+        }
+    }
+
+    #[test]
+    fn decode_truncated_channel_id() {
+        assert_eq!(
+            Stfu::decode(&[0x00; 20]),
+            Err(BoltError::Truncated {
+                expected: CHANNEL_ID_SIZE,
+                actual: 20
+            })
+        );
+    }
+
+    #[test]
+    fn decode_missing_initiator() {
+        assert_eq!(
+            Stfu::decode(&[0x00; CHANNEL_ID_SIZE]),
+            Err(BoltError::Truncated {
+                expected: 1,
+                actual: 0
+            })
+        );
+    }
+
+    #[test]
+    fn decode_empty() {
+        assert_eq!(
+            Stfu::decode(&[]),
+            Err(BoltError::Truncated {
+                expected: CHANNEL_ID_SIZE,
+                actual: 0
+            })
+        );
+    }
+
+    #[test]
+    fn decode_ignores_trailing_bytes() {
+        let mut data = vec![0xff; CHANNEL_ID_SIZE];
+        data.extend_from_slice(&[0x01, 0xaa, 0xbb]);
+        let decoded = Stfu::decode(&data).unwrap();
+        assert_eq!(decoded.channel_id, ChannelId::new([0xff; CHANNEL_ID_SIZE]));
+        assert_eq!(decoded.initiator, 1);
+    }
+}


### PR DESCRIPTION
Add the BOLT 2 stfu message (type 2) used to quiesce a channel under option_quiesce: channel_id followed by a u8 initiator flag.

It's going to be needed for splicing. Also, while fuzzing CLN with #239, it would sometimes crash when receiving an unknown stfu message.