### PR TITLE
bitcoind: replace bitcoin-cli with a keep-alive JSON-RPC client

### DIFF
--- a/smite-ir/src/operation.rs
+++ b/smite-ir/src/operation.rs
@@ -230,7 +230,7 @@ pub enum Operation {
     RecvChannelReady,
     /// Mines the given number of blocks on the Bitcoin network.
     MineBlocks(u8),
-    /// Sign wallet inputs of the transaction and broadcast it via `bitcoin-cli`.
+    /// Sign wallet inputs of the transaction and broadcast it via `bitcoind`.
     /// Input: `FundingTransaction`.
     BroadcastTransaction,
     // -- Query: read state from outside the program --

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -60,7 +60,7 @@ pub const RECV_IDLE_TIMEOUT: Duration = Duration::from_secs(1);
 /// reconfiguring or patching CLN to poll more frequently.
 pub const RECV_CHANNEL_READY_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Abstraction over bitcoin-cli operations, allowing mock implementations in tests.
+/// Abstraction over bitcoind operations, allowing mock implementations in tests.
 pub trait BitcoinRpc {
     /// Mines the given number of blocks, including any transactions in the
     /// `private_mempool` in the first block.
@@ -264,7 +264,7 @@ pub struct Executor<C, B, R> {
 }
 
 impl<C: Connection, B: BitcoinRpc, R: TargetRpc> Executor<C, B, R> {
-    /// Creates an executor with the given connection, bitcoin-cli handle,
+    /// Creates an executor with the given connection, bitcoind client,
     /// program context, and target RPC handle. Channel state and negotiations
     /// start empty.
     pub fn new(conn: C, bitcoind_client: B, rpc: R, context: ProgramContext) -> Self {

--- a/smite-scenarios/src/executor.rs
+++ b/smite-scenarios/src/executor.rs
@@ -6,7 +6,7 @@
 use bitcoin::secp256k1::ecdsa::Signature;
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use bitcoin::{OutPoint, ScriptBuf, Txid};
-use smite::bitcoin::{BitcoinCli, TxBlockPosition, Utxo};
+use smite::bitcoin::{BitcoindClient, TxBlockPosition, Utxo};
 use smite::bolt::{
     AcceptChannel, AnnouncementSignatures, ChannelAnnouncement, ChannelId, ChannelReady,
     ChannelReadyTlvs, ChannelUpdate, Features, FundingCreated, FundingSigned, Message, MessageType,
@@ -96,33 +96,33 @@ pub trait BitcoinRpc {
     fn get_transaction_block_position(&mut self, txid: Txid) -> Option<TxBlockPosition>;
 }
 
-impl BitcoinRpc for BitcoinCli {
+impl BitcoinRpc for BitcoindClient {
     fn mine_blocks(&mut self, num_blocks: u8, private_mempool: &[String]) {
-        BitcoinCli::mine_blocks(self, num_blocks, private_mempool);
+        BitcoindClient::mine_blocks(self, num_blocks, private_mempool);
     }
 
     fn get_utxos(&mut self) -> Vec<Utxo> {
-        BitcoinCli::get_utxos(self)
+        BitcoindClient::get_utxos(self)
     }
 
     fn get_new_address_script_pubkey(&mut self) -> ScriptBuf {
-        BitcoinCli::get_new_address_script_pubkey(self)
+        BitcoindClient::get_new_address_script_pubkey(self)
     }
 
     fn sign_and_broadcast_tx(&mut self, tx: &bitcoin::Transaction) -> Option<String> {
-        BitcoinCli::sign_and_broadcast_tx(self, tx)
+        BitcoindClient::sign_and_broadcast_tx(self, tx)
     }
 
     fn lock_utxos(&mut self, outpoints: &[OutPoint]) {
-        BitcoinCli::lock_utxos(self, outpoints);
+        BitcoindClient::lock_utxos(self, outpoints);
     }
 
     fn get_transaction_confirmations(&mut self, txid: Txid) -> u32 {
-        BitcoinCli::get_transaction_confirmations(self, txid)
+        BitcoindClient::get_transaction_confirmations(self, txid)
     }
 
     fn get_transaction_block_position(&mut self, txid: Txid) -> Option<TxBlockPosition> {
-        BitcoinCli::get_transaction_block_position(self, txid)
+        BitcoindClient::get_transaction_block_position(self, txid)
     }
 }
 
@@ -235,7 +235,7 @@ pub struct Executor<C, B, R> {
     /// Connection used to send and receive Lightning messages.
     conn: C,
     /// Interface to bitcoind for wallet and chain operations.
-    bitcoin_cli: B,
+    bitcoind_client: B,
     /// Interface for interacting with the target node through RPC.
     rpc: R,
     /// Immutable state captured during snapshot setup.
@@ -267,10 +267,10 @@ impl<C: Connection, B: BitcoinRpc, R: TargetRpc> Executor<C, B, R> {
     /// Creates an executor with the given connection, bitcoin-cli handle,
     /// program context, and target RPC handle. Channel state and negotiations
     /// start empty.
-    pub fn new(conn: C, bitcoin_cli: B, rpc: R, context: ProgramContext) -> Self {
+    pub fn new(conn: C, bitcoind_client: B, rpc: R, context: ProgramContext) -> Self {
         Self {
             conn,
-            bitcoin_cli,
+            bitcoind_client,
             rpc,
             context,
             channel_states: HashMap::new(),
@@ -307,7 +307,7 @@ impl<C: Connection, B: BitcoinRpc, R: TargetRpc> Executor<C, B, R> {
     /// - input variable index out of bounds
     /// - input variable refers to a void instruction
     /// - input variable has the wrong type
-    /// - `MineBlocks(0)` (panics inside `BitcoinCli::mine_blocks`)
+    /// - `MineBlocks(0)` (panics inside `BitcoindClient::mine_blocks`)
     /// - `LoadShutdownScript(AnySegwit { .. })` with an out-of-range version or
     ///   program length (panics inside the encoder)
     /// - `LoadBytes` / `LoadFeatures` payload exceeding `MAX_MESSAGE_SIZE` (panics
@@ -377,7 +377,7 @@ impl<C: Connection, B: BitcoinRpc, R: TargetRpc> Executor<C, B, R> {
                     let ft = create_funding_transaction(
                         &variables,
                         &instr.inputs,
-                        &mut self.bitcoin_cli,
+                        &mut self.bitcoind_client,
                     )?;
                     Some(Variable::FundingTransaction(ft))
                 }
@@ -521,7 +521,7 @@ impl<C: Connection, B: BitcoinRpc, R: TargetRpc> Executor<C, B, R> {
                 }
 
                 Operation::RecvChannelReady => {
-                    if is_channel_ready_expected(&self.channel_states, &mut self.bitcoin_cli) {
+                    if is_channel_ready_expected(&self.channel_states, &mut self.bitcoind_client) {
                         log::debug!("[{:?}] RecvChannelReady: waiting", start.elapsed());
                         recv_channel_ready(&mut self.conn, &mut self.channel_states)?;
                         log::debug!("[{:?}] RecvChannelReady: received", start.elapsed());
@@ -536,7 +536,7 @@ impl<C: Connection, B: BitcoinRpc, R: TargetRpc> Executor<C, B, R> {
                         .into_iter()
                         .map(|(_, hex)| hex)
                         .collect();
-                    self.bitcoin_cli.mine_blocks(*v, &private_mempool);
+                    self.bitcoind_client.mine_blocks(*v, &private_mempool);
                     self.rpc.chain_sync();
                     self.mined_txids.extend(self.unmined_txids.drain());
                     log::debug!("[{:?}] MineBlocks: mined {} block(s)", start.elapsed(), v);
@@ -555,7 +555,7 @@ impl<C: Connection, B: BitcoinRpc, R: TargetRpc> Executor<C, B, R> {
                     // mempool so they can be mined later. Dedup on txid so the
                     // same transaction broadcast again before then is queued
                     // once, regardless of any change to its signed hex.
-                    if let Some(hex) = self.bitcoin_cli.sign_and_broadcast_tx(&ft.tx)
+                    if let Some(hex) = self.bitcoind_client.sign_and_broadcast_tx(&ft.tx)
                         && !self.private_mempool.iter().any(|(t, _)| *t == txid)
                     {
                         self.private_mempool.push((txid, hex));
@@ -573,7 +573,7 @@ impl<C: Connection, B: BitcoinRpc, R: TargetRpc> Executor<C, B, R> {
                     // message will simply fail on-chain validation, which is
                     // the intended fuzzing behaviour for a valid but
                     // unconfirmed program.
-                    let scid = match self.bitcoin_cli.get_transaction_block_position(txid) {
+                    let scid = match self.bitcoind_client.get_transaction_block_position(txid) {
                         Some(pos) => {
                             let funding_output_index =
                                 u16::try_from(ft.vout).expect("funding output index fits in u16");
@@ -1229,14 +1229,14 @@ fn recv_channel_ready(
 /// `accept_channel`).
 fn is_channel_ready_expected(
     channel_states: &HashMap<ChannelId, ChannelState>,
-    bitcoin_cli: &mut impl BitcoinRpc,
+    bitcoind_client: &mut impl BitcoinRpc,
 ) -> bool {
     channel_states.values().any(|state| {
         state.commitment.commitment_number == 0
             && state.next_counterparty_per_commitment_point().is_none()
             && state.is_funding_outpoint_valid
             && !state.was_funding_mined_prematurely
-            && bitcoin_cli.get_transaction_confirmations(state.config.funding_outpoint.txid)
+            && bitcoind_client.get_transaction_confirmations(state.config.funding_outpoint.txid)
                 >= state.config.minimum_depth
     })
 }

--- a/smite-scenarios/src/executor/tests.rs
+++ b/smite-scenarios/src/executor/tests.rs
@@ -46,7 +46,7 @@ fn execute_load_build_send() {
     };
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -131,7 +131,7 @@ fn execute_build_channel_announcement() {
     };
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -199,7 +199,7 @@ fn execute_build_node_announcement() {
     };
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -292,7 +292,7 @@ fn execute_build_channel_update() {
     };
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -404,7 +404,7 @@ fn execute_build_announcement_signatures() {
     };
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -498,7 +498,7 @@ fn execute_build_open_channel_with_tlvs() {
     };
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -548,7 +548,7 @@ fn execute_derive_point() {
     };
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -610,7 +610,7 @@ fn execute_recv_and_extract_all_fields() {
     };
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -636,7 +636,7 @@ fn execute_recv_unexpected_message() {
     };
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -670,7 +670,7 @@ fn execute_recv_peer_error() {
     };
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -703,7 +703,7 @@ fn execute_recv_auto_pong() {
     };
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -744,7 +744,7 @@ fn execute_recv_skips_gossip() {
     });
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -781,7 +781,7 @@ fn execute_records_negotiation_for_open_and_accept() {
     });
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -822,7 +822,7 @@ fn execute_recv_accept_channel_unknown_channel() {
     });
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -867,7 +867,7 @@ fn execute_recv_accept_channel_opener_cannot_afford_fee() {
 
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -916,7 +916,7 @@ fn execute_recv_accept_channel_rejects_reuse_before_funding() {
 
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -969,7 +969,7 @@ fn execute_records_only_first_open_channel_for_duplicate_id_before_funding() {
 
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -1000,7 +1000,7 @@ fn execute_records_only_first_open_channel_for_duplicate_id_before_funding() {
 #[test]
 fn execute_records_open_channel_for_duplicate_id_after_funding() {
     let temporary_channel_id = TemporaryChannelId::new([0xbb; 32]);
-    let mock_cli = MockBitcoinCli {
+    let mock_cli = MockBitcoindClient {
         utxos: vec![sample_utxo()],
         change_spk: sample_change_spk(),
         ..Default::default()
@@ -1057,7 +1057,7 @@ fn execute_wrong_input_count_panics() {
     };
     let _ = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     )
@@ -1081,7 +1081,7 @@ fn execute_type_mismatch_panics() {
     };
     let _ = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     )
@@ -1099,7 +1099,7 @@ fn execute_variable_out_of_bounds_panics() {
     };
     let _ = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     )
@@ -1123,7 +1123,7 @@ fn execute_forward_variable_reference_panics() {
     };
     let _ = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     )
@@ -1148,7 +1148,7 @@ fn execute_void_variable_reference_panics() {
     };
     let _ = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     )
@@ -1172,7 +1172,7 @@ fn execute_invalid_private_key_panics() {
     };
     let _ = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     )
@@ -1199,7 +1199,7 @@ fn execute_send_open_channel_wrong_type_panics() {
 
     let _ = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     )
@@ -1227,7 +1227,7 @@ fn execute_affine_overuse_panics() {
     let ac_bytes = Message::AcceptChannel(sample_accept_channel()).encode();
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -1247,7 +1247,7 @@ fn execute_mine_blocks_invokes_cli() {
     };
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -1256,8 +1256,8 @@ fn execute_mine_blocks_invokes_cli() {
         .unwrap();
 
     // Verify that mine_blocks was called with the correct number
-    assert_eq!(executor.bitcoin_cli.mine_blocks_calls, vec![6]);
-    assert!(executor.bitcoin_cli.mined_private_mempool.is_empty());
+    assert_eq!(executor.bitcoind_client.mine_blocks_calls, vec![6]);
+    assert!(executor.bitcoind_client.mined_private_mempool.is_empty());
     assert_eq!(executor.rpc.chain_syncs, 1);
 }
 
@@ -1279,7 +1279,7 @@ fn execute_mine_blocks_wrong_input() {
     };
     let _ = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     )
@@ -1288,7 +1288,7 @@ fn execute_mine_blocks_wrong_input() {
 
 #[test]
 fn execute_create_and_broadcast_tx() {
-    let mock_cli = MockBitcoinCli {
+    let mock_cli = MockBitcoindClient {
         utxos: vec![sample_utxo()],
         change_spk: sample_change_spk(),
         ..Default::default()
@@ -1308,8 +1308,8 @@ fn execute_create_and_broadcast_tx() {
         )
         .expect("tx construction and broadcast should succeed");
 
-    assert_eq!(executor.bitcoin_cli.broadcast_calls.len(), 1);
-    let broadcast_tx = &executor.bitcoin_cli.broadcast_calls[0];
+    assert_eq!(executor.bitcoind_client.broadcast_calls.len(), 1);
+    let broadcast_tx = &executor.bitcoind_client.broadcast_calls[0];
     assert_eq!(
         broadcast_tx.compute_txid().to_string(),
         "09b0549b35f14ee862f63bd75811c6c27963c4dea6766ec6836952ec78df1e7e"
@@ -1322,7 +1322,7 @@ fn execute_create_and_broadcast_tx() {
 // by feeding it into a channel_announcement and decoding the sent message.
 #[test]
 fn execute_lookup_short_channel_id_confirmed() {
-    let mock_cli = MockBitcoinCli {
+    let mock_cli = MockBitcoindClient {
         utxos: vec![sample_utxo()],
         change_spk: sample_change_spk(),
         ..Default::default()
@@ -1357,13 +1357,13 @@ fn execute_lookup_short_channel_id_confirmed() {
         )
         .expect("lookup after confirmation should succeed");
 
-    assert_eq!(executor.bitcoin_cli.mine_blocks_calls, vec![6]);
+    assert_eq!(executor.bitcoind_client.mine_blocks_calls, vec![6]);
     // The executor must have queried the mock with the broadcast
     // transaction's txid.
-    assert_eq!(executor.bitcoin_cli.block_position_lookups.len(), 1);
-    let broadcast_txid = executor.bitcoin_cli.broadcast_calls[0].compute_txid();
+    assert_eq!(executor.bitcoind_client.block_position_lookups.len(), 1);
+    let broadcast_txid = executor.bitcoind_client.broadcast_calls[0].compute_txid();
     assert_eq!(
-        executor.bitcoin_cli.block_position_lookups[0],
+        executor.bitcoind_client.block_position_lookups[0],
         broadcast_txid,
     );
 
@@ -1379,7 +1379,7 @@ fn execute_lookup_short_channel_id_confirmed() {
 // via the SCID carried in a channel_announcement.
 #[test]
 fn execute_lookup_short_channel_id_unconfirmed_returns_sentinel() {
-    let mock_cli = MockBitcoinCli {
+    let mock_cli = MockBitcoindClient {
         utxos: vec![sample_utxo()],
         change_spk: sample_change_spk(),
         ..Default::default()
@@ -1439,8 +1439,8 @@ fn execute_lookup_short_channel_id_unconfirmed_returns_sentinel() {
         .expect("lookup on unconfirmed tx should not fail");
     // The mock was queried but returned None (zero confirmations), so the
     // executor took the sentinel path without panicking.
-    assert!(executor.bitcoin_cli.mine_blocks_calls.is_empty());
-    assert_eq!(executor.bitcoin_cli.block_position_lookups.len(), 1);
+    assert!(executor.bitcoind_client.mine_blocks_calls.is_empty());
+    assert_eq!(executor.bitcoind_client.block_position_lookups.len(), 1);
 
     let ca = decode_sent_channel_announcement(&executor.conn.sent[0]);
     assert_eq!(ca.short_channel_id, ShortChannelId::new(0, 0, 0));
@@ -1448,7 +1448,7 @@ fn execute_lookup_short_channel_id_unconfirmed_returns_sentinel() {
 
 #[test]
 fn execute_broadcast_dedupes_rejected_tx_in_private_mempool() {
-    let mock_cli = MockBitcoinCli {
+    let mock_cli = MockBitcoindClient {
         utxos: vec![sample_utxo()],
         change_spk: sample_change_spk(),
         ..Default::default()
@@ -1486,17 +1486,17 @@ fn execute_broadcast_dedupes_rejected_tx_in_private_mempool() {
         )
         .unwrap();
 
-    assert_eq!(executor.bitcoin_cli.broadcast_calls.len(), 2);
+    assert_eq!(executor.bitcoind_client.broadcast_calls.len(), 2);
     assert_eq!(
-        executor.bitcoin_cli.broadcast_calls[0].compute_txid(),
-        executor.bitcoin_cli.broadcast_calls[1].compute_txid(),
+        executor.bitcoind_client.broadcast_calls[0].compute_txid(),
+        executor.bitcoind_client.broadcast_calls[1].compute_txid(),
     );
 
     let rejected_hex =
-        bitcoin::consensus::encode::serialize_hex(&executor.bitcoin_cli.broadcast_calls[0]);
+        bitcoin::consensus::encode::serialize_hex(&executor.bitcoind_client.broadcast_calls[0]);
     assert!(executor.private_mempool.is_empty());
     assert_eq!(
-        executor.bitcoin_cli.mined_private_mempool,
+        executor.bitcoind_client.mined_private_mempool,
         vec![rejected_hex]
     );
 }
@@ -1508,7 +1508,7 @@ fn execute_create_funding_transaction_insufficient_funds() {
         amount: Amount::from_sat(1_000),
         ..sample_utxo()
     };
-    let mock_cli = MockBitcoinCli {
+    let mock_cli = MockBitcoindClient {
         utxos: vec![small_utxo],
         change_spk: sample_change_spk(),
         ..Default::default()
@@ -1535,7 +1535,7 @@ fn execute_create_funding_transaction_insufficient_funds() {
 
 #[test]
 fn execute_send_funding_created_and_recv_funding_signed() {
-    let mock_cli = MockBitcoinCli {
+    let mock_cli = MockBitcoindClient {
         utxos: vec![sample_utxo()],
         change_spk: sample_change_spk(),
         ..Default::default()
@@ -1617,7 +1617,7 @@ fn execute_send_funding_created_and_recv_funding_signed() {
 
 #[test]
 fn execute_send_funding_created_uses_wire_funding_pubkey() {
-    let mock_cli = MockBitcoinCli {
+    let mock_cli = MockBitcoindClient {
         utxos: vec![sample_utxo()],
         change_spk: sample_change_spk(),
         ..Default::default()
@@ -1699,7 +1699,7 @@ fn execute_send_funding_created_after_funding_built_does_not_track_channel() {
         },
         ..sample_utxo()
     };
-    let mock_cli = MockBitcoinCli {
+    let mock_cli = MockBitcoindClient {
         utxos: vec![sample_utxo(), second_utxo],
         change_spk: sample_change_spk(),
         ..Default::default()
@@ -1758,7 +1758,7 @@ fn execute_send_funding_created_push_exceeds_funding() {
     // commitment construction error.
     let mut negotiation = sample_funding_negotiation();
     negotiation.open_channel.push_msat = 20_000_000_000;
-    let mock_cli = MockBitcoinCli {
+    let mock_cli = MockBitcoindClient {
         utxos: vec![sample_utxo()],
         change_spk: sample_change_spk(),
         ..Default::default()
@@ -1792,7 +1792,7 @@ fn execute_send_funding_created_funding_msat_overflow() {
     // millisatoshis.
     let mut negotiation = sample_funding_negotiation();
     negotiation.open_channel.funding_satoshis = u64::MAX;
-    let mock_cli = MockBitcoinCli {
+    let mock_cli = MockBitcoindClient {
         utxos: vec![sample_utxo()],
         change_spk: sample_change_spk(),
         ..Default::default()
@@ -1825,7 +1825,7 @@ fn execute_send_funding_created_no_open_channel() {
     // No negotiation exists for this temporary_channel_id, so we get a
     // `funding_created` with an all-zero signature and no recorded channel
     // state.
-    let mock_cli = MockBitcoinCli {
+    let mock_cli = MockBitcoindClient {
         utxos: vec![sample_utxo()],
         change_spk: sample_change_spk(),
         ..Default::default()
@@ -1869,7 +1869,7 @@ fn execute_send_funding_created_no_accept_channel() {
     // state.
     let mut negotiation = sample_funding_negotiation();
     negotiation.accept_channel = None;
-    let mock_cli = MockBitcoinCli {
+    let mock_cli = MockBitcoindClient {
         utxos: vec![sample_utxo()],
         change_spk: sample_change_spk(),
         ..Default::default()
@@ -1911,7 +1911,7 @@ fn execute_send_funding_created_no_accept_channel() {
 
 #[test]
 fn execute_recv_funding_signed_unknown_channel() {
-    let mock_cli = MockBitcoinCli {
+    let mock_cli = MockBitcoindClient {
         utxos: vec![sample_utxo()],
         change_spk: sample_change_spk(),
         ..Default::default()
@@ -1954,7 +1954,7 @@ fn execute_recv_funding_signed_unknown_channel() {
 
 #[test]
 fn execute_recv_funding_signed_invalid_signature() {
-    let mock_cli = MockBitcoinCli {
+    let mock_cli = MockBitcoindClient {
         utxos: vec![sample_utxo()],
         change_spk: sample_change_spk(),
         ..Default::default()
@@ -2006,7 +2006,7 @@ fn execute_send_channel_ready() {
         vout: 0,
     });
     let alias = ShortChannelId::new(538_532, 845, 1);
-    let mock_cli = MockBitcoinCli {
+    let mock_cli = MockBitcoindClient {
         utxos: vec![sample_utxo()],
         change_spk: sample_change_spk(),
         ..Default::default()
@@ -2121,7 +2121,7 @@ fn execute_send_shutdown() {
 
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -2162,7 +2162,7 @@ fn execute_send_shutdown_empty_scriptpubkey() {
 
     let mut executor = Executor::new(
         MockConnection::new(),
-        MockBitcoinCli::default(),
+        MockBitcoindClient::default(),
         MockTargetRpc::default(),
         sample_context(),
     );
@@ -2180,7 +2180,7 @@ fn execute_send_shutdown_empty_scriptpubkey() {
 }
 
 fn recv_channel_ready_executor() -> (
-    Executor<MockConnection, MockBitcoinCli, MockTargetRpc>,
+    Executor<MockConnection, MockBitcoindClient, MockTargetRpc>,
     ChannelId,
     PublicKey,
 ) {
@@ -2190,7 +2190,7 @@ fn recv_channel_ready_executor() -> (
             .unwrap(),
         vout: 0,
     });
-    let mock_cli = MockBitcoinCli {
+    let mock_cli = MockBitcoindClient {
         utxos: vec![sample_utxo()],
         change_spk: sample_change_spk(),
         ..Default::default()
@@ -2300,7 +2300,7 @@ fn execute_recv_channel_ready_below_minimum_depth_is_noop() {
             std::time::Instant::now(),
         )
         .unwrap();
-    assert!(executor.bitcoin_cli.mined_private_mempool.is_empty());
+    assert!(executor.bitcoind_client.mined_private_mempool.is_empty());
 
     // The target's next per-commitment point is still unknown and the queued
     // `channel_ready` remains untouched.
@@ -2327,7 +2327,7 @@ fn execute_recv_channel_ready_at_minimum_depth_records_point() {
             std::time::Instant::now(),
         )
         .unwrap();
-    assert!(executor.bitcoin_cli.mined_private_mempool.is_empty());
+    assert!(executor.bitcoind_client.mined_private_mempool.is_empty());
 
     // The `channel_ready` was consumed and the target's next per-commitment
     // point is now recorded.

--- a/smite-scenarios/src/executor/tests/harness.rs
+++ b/smite-scenarios/src/executor/tests/harness.rs
@@ -47,10 +47,10 @@ impl Connection for MockConnection {
     }
 }
 
-// Mocking BitcoinCli via MockBitcoinCli
+// Mocking BitcoindClient via MockBitcoindClient
 
 #[derive(Default)]
-pub struct MockBitcoinCli {
+pub struct MockBitcoindClient {
     pub mine_blocks_calls: Vec<u8>,
     pub mined_private_mempool: Vec<String>,
     pub broadcast_calls: Vec<Transaction>,
@@ -60,7 +60,7 @@ pub struct MockBitcoinCli {
     pub confirmations: u32,
 }
 
-impl BitcoinRpc for MockBitcoinCli {
+impl BitcoinRpc for MockBitcoindClient {
     fn mine_blocks(&mut self, num_blocks: u8, private_mempool: &[String]) {
         self.mine_blocks_calls.push(num_blocks);
         self.mined_private_mempool = private_mempool.to_vec();

--- a/smite-scenarios/src/scenarios/ir.rs
+++ b/smite-scenarios/src/scenarios/ir.rs
@@ -3,7 +3,7 @@
 
 use std::marker::PhantomData;
 
-use smite::bitcoin::BitcoinCli;
+use smite::bitcoin::BitcoindClient;
 use smite::noise::NoiseConnection;
 use smite::scenarios::{Scenario, ScenarioError, ScenarioResult};
 use smite::violation::Violation;
@@ -24,7 +24,7 @@ pub struct IrScenario<T: Target, S: SnapshotSetup<T>> {
     /// Executes IR programs and owns the connection, bitcoin-cli handle,
     /// program context, and the target's RPC handle. Created once before the
     /// snapshot and reused across fuzzing runs.
-    executor: Executor<NoiseConnection, BitcoinCli, T::Rpc>,
+    executor: Executor<NoiseConnection, BitcoindClient, T::Rpc>,
     // S is only used for static dispatch on S::setup(), not stored.
     _phantom: PhantomData<S>,
 }
@@ -33,8 +33,8 @@ impl<T: Target, S: SnapshotSetup<T>> Scenario for IrScenario<T, S> {
     fn new(_args: &[String]) -> Result<Self, ScenarioError> {
         let target = T::start(T::Config::default())?;
         let (conn, context) = S::setup(&target)?;
-        let bitcoin_cli = target.bitcoin_cli().clone();
-        let executor = Executor::new(conn, bitcoin_cli, target.rpc(), context);
+        let bitcoind_client = target.bitcoind_client().clone();
+        let executor = Executor::new(conn, bitcoind_client, target.rpc(), context);
         Ok(Self {
             target,
             executor,

--- a/smite-scenarios/src/scenarios/ir.rs
+++ b/smite-scenarios/src/scenarios/ir.rs
@@ -21,7 +21,7 @@ use crate::targets::Target;
 /// (out-of-bounds variable refs, type mismatches, `MineBlocks(0)`, etc.).
 pub struct IrScenario<T: Target, S: SnapshotSetup<T>> {
     target: T,
-    /// Executes IR programs and owns the connection, bitcoin-cli handle,
+    /// Executes IR programs and owns the connection, bitcoind client,
     /// program context, and the target's RPC handle. Created once before the
     /// snapshot and reused across fuzzing runs.
     executor: Executor<NoiseConnection, BitcoindClient, T::Rpc>,

--- a/smite-scenarios/src/targets.rs
+++ b/smite-scenarios/src/targets.rs
@@ -11,7 +11,7 @@ pub use cln::{ClnConfig, ClnRpc, ClnTarget};
 pub use eclair::{EclairConfig, EclairRpc, EclairTarget};
 pub use ldk::{LdkConfig, LdkRpc, LdkTarget};
 pub use lnd::{LndConfig, LndRpc, LndTarget};
-use smite::bitcoin::BitcoinCli;
+use smite::bitcoin::BitcoindClient;
 use smite::scenarios::TargetError;
 
 use bitcoin::secp256k1;
@@ -77,7 +77,7 @@ pub trait Target: Sized {
     fn rpc(&self) -> Self::Rpc;
 
     /// `bitcoin-cli` wrapper for the regtest `bitcoind` instance.
-    fn bitcoin_cli(&self) -> &BitcoinCli;
+    fn bitcoind_client(&self) -> &BitcoindClient;
 
     /// Check if target is still alive. Returns `Err(Crashed)` if dead.
     ///

--- a/smite-scenarios/src/targets.rs
+++ b/smite-scenarios/src/targets.rs
@@ -76,7 +76,7 @@ pub trait Target: Sized {
     /// Target's RPC handle for executing commands.
     fn rpc(&self) -> Self::Rpc;
 
-    /// `bitcoin-cli` wrapper for the regtest `bitcoind` instance.
+    /// JSON-RPC client for the regtest `bitcoind` instance.
     fn bitcoind_client(&self) -> &BitcoindClient;
 
     /// Check if target is still alive. Returns `Err(Crashed)` if dead.

--- a/smite-scenarios/src/targets/bitcoind.rs
+++ b/smite-scenarios/src/targets/bitcoind.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
-use smite::bitcoin::BitcoinCli;
+use smite::bitcoin::BitcoindClient;
 use smite::process::ManagedProcess;
 
 use super::TargetError;
@@ -63,7 +63,7 @@ pub fn resolve_data_dir() -> Result<(PathBuf, Option<tempfile::TempDir>), Target
 pub fn start(
     config: &BitcoindConfig,
     data_dir: &Path,
-) -> Result<(ManagedProcess, BitcoinCli), TargetError> {
+) -> Result<(ManagedProcess, BitcoindClient), TargetError> {
     log::info!("Starting bitcoind...");
 
     let bitcoind_dir = data_dir.join("bitcoind");
@@ -101,10 +101,7 @@ pub fn start(
     }
 
     let bitcoind = ManagedProcess::spawn(&mut cmd, "bitcoind")?;
-    let cli = BitcoinCli {
-        rpc_port: config.rpc_port,
-        bitcoind_dir,
-    };
+    let cli = BitcoindClient::new(config.rpc_port, bitcoind_dir);
 
     // Wait for bitcoind to be ready
     log::info!("Waiting for bitcoind to be ready...");
@@ -131,7 +128,7 @@ pub fn start(
 }
 
 /// Creates wallet and generates initial blocks.
-fn setup_wallet(cli: &BitcoinCli) -> Result<(), TargetError> {
+fn setup_wallet(cli: &BitcoindClient) -> Result<(), TargetError> {
     // Create wallet
     let status = cli
         .run()

--- a/smite-scenarios/src/targets/bitcoind.rs
+++ b/smite-scenarios/src/targets/bitcoind.rs
@@ -101,25 +101,18 @@ pub fn start(
     }
 
     let bitcoind = ManagedProcess::spawn(&mut cmd, "bitcoind")?;
-    let cli = BitcoindClient::new(config.rpc_port, bitcoind_dir);
+    let mut client = BitcoindClient::new(config.rpc_port);
 
     // Wait for bitcoind to be ready
     log::info!("Waiting for bitcoind to be ready...");
     for _ in 0..30 {
-        let status = cli
-            .run()
-            .arg("getblockchaininfo")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status();
-
-        if status.is_ok_and(|s| s.success()) {
-            log::info!("bitcoind is ready");
-            setup_wallet(&cli)?;
-            return Ok((bitcoind, cli));
-        }
-
         std::thread::sleep(Duration::from_secs(1));
+
+        if client.is_ready() {
+            log::info!("bitcoind is ready");
+            setup_wallet(&mut client)?;
+            return Ok((bitcoind, client));
+        }
     }
 
     Err(TargetError::StartFailed(
@@ -128,37 +121,18 @@ pub fn start(
 }
 
 /// Creates wallet and generates initial blocks.
-fn setup_wallet(cli: &BitcoindClient) -> Result<(), TargetError> {
-    // Create wallet
-    let status = cli
-        .run()
-        .arg("createwallet")
-        .arg("default")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()?;
+fn setup_wallet(client: &mut BitcoindClient) -> Result<(), TargetError> {
+    // Fails if the wallet already exists (i.e. SMITE_DATA_DIR was mounted).
+    client.create_wallet("default").map_err(|e| {
+        TargetError::StartFailed(format!(
+            "failed to create wallet (does it already exist?): {e}"
+        ))
+    })?;
 
-    // command fails if wallet already exists (i.e. SMITE_DATA_DIR was mounted)
-    if !status.success() {
-        return Err(TargetError::StartFailed(
-            "failed to create wallet (does it already exist?)".into(),
-        ));
-    }
-
-    // Generate initial blocks
-    let status = cli
-        .run()
-        .arg("-generate")
-        .arg(INITIAL_BLOCKS.to_string())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()?;
-
-    if !status.success() {
-        return Err(TargetError::StartFailed(
-            "failed to generate initial blocks".into(),
-        ));
-    }
+    let initial_blocks = u32::try_from(INITIAL_BLOCKS).expect("fits in u32");
+    client
+        .generate(initial_blocks)
+        .map_err(|e| TargetError::StartFailed(format!("failed to generate initial blocks: {e}")))?;
 
     Ok(())
 }

--- a/smite-scenarios/src/targets/cln.rs
+++ b/smite-scenarios/src/targets/cln.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use bitcoin::secp256k1;
 use serde::Deserialize;
-use smite::bitcoin::BitcoinCli;
+use smite::bitcoin::BitcoindClient;
 use smite::process::ManagedProcess;
 
 use super::bitcoind;
@@ -174,7 +174,7 @@ pub struct ClnTarget {
     pubkey: secp256k1::PublicKey,
     addr: SocketAddr,
     cln_dir: PathBuf,
-    bitcoin_cli: BitcoinCli,
+    bitcoind_client: BitcoindClient,
     #[allow(dead_code)] // TempDir auto-cleans on drop
     temp_dir: Option<tempfile::TempDir>,
 }
@@ -319,7 +319,7 @@ impl Target for ClnTarget {
     fn start(config: Self::Config) -> Result<Self, TargetError> {
         let (data_path, temp_dir) = bitcoind::resolve_data_dir()?;
 
-        let (bitcoind, bitcoin_cli) = bitcoind::start(&config.bitcoind_config(), &data_path)?;
+        let (bitcoind, bitcoind_client) = bitcoind::start(&config.bitcoind_config(), &data_path)?;
         let (cln, pubkey, cln_dir) = Self::start_cln(&config, &data_path)?;
         let addr = SocketAddr::from(([127, 0, 0, 1], config.cln_p2p_port));
 
@@ -331,7 +331,7 @@ impl Target for ClnTarget {
             pubkey,
             addr,
             cln_dir,
-            bitcoin_cli,
+            bitcoind_client,
             temp_dir,
         })
     }
@@ -350,8 +350,8 @@ impl Target for ClnTarget {
         }
     }
 
-    fn bitcoin_cli(&self) -> &BitcoinCli {
-        &self.bitcoin_cli
+    fn bitcoind_client(&self) -> &BitcoindClient {
+        &self.bitcoind_client
     }
 
     fn check_alive(&mut self) -> Result<(), TargetError> {

--- a/smite-scenarios/src/targets/cln.rs
+++ b/smite-scenarios/src/targets/cln.rs
@@ -196,7 +196,7 @@ impl ClnTarget {
         let mut cmd = Command::new("lightningd");
 
         // LD_PRELOAD the crash handler into lightningd and its subdaemons.
-        // Set only on lightningd (not lightning-cli/bitcoin-cli) to avoid
+        // Set only on lightningd (not lightning-cli) to avoid
         // interfering with helper processes.
         if let Ok(handler) = std::env::var("SMITE_CRASH_HANDLER") {
             cmd.env("LD_PRELOAD", handler);

--- a/smite-scenarios/src/targets/eclair.rs
+++ b/smite-scenarios/src/targets/eclair.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use bitcoin::secp256k1;
 use serde::Deserialize;
-use smite::bitcoin::BitcoinCli;
+use smite::bitcoin::BitcoindClient;
 use smite::process::ManagedProcess;
 
 use super::bitcoind;
@@ -84,7 +84,7 @@ pub struct EclairTarget {
     bitcoind: ManagedProcess,
     pubkey: secp256k1::PublicKey,
     addr: SocketAddr,
-    bitcoin_cli: BitcoinCli,
+    bitcoind_client: BitcoindClient,
     #[allow(dead_code)] // TempDir auto-cleans on drop
     temp_dir: Option<tempfile::TempDir>,
 }
@@ -212,7 +212,7 @@ impl Target for EclairTarget {
     fn start(config: Self::Config) -> Result<Self, TargetError> {
         let (data_path, temp_dir) = bitcoind::resolve_data_dir()?;
 
-        let (bitcoind, bitcoin_cli) = bitcoind::start(&config.bitcoind_config(), &data_path)?;
+        let (bitcoind, bitcoind_client) = bitcoind::start(&config.bitcoind_config(), &data_path)?;
         let (eclair, pubkey) = Self::start_eclair(&config, &data_path)?;
         let addr = SocketAddr::from(([127, 0, 0, 1], config.eclair_p2p_port));
 
@@ -223,7 +223,7 @@ impl Target for EclairTarget {
             bitcoind,
             pubkey,
             addr,
-            bitcoin_cli,
+            bitcoind_client,
             temp_dir,
         })
     }
@@ -240,8 +240,8 @@ impl Target for EclairTarget {
         EclairRpc
     }
 
-    fn bitcoin_cli(&self) -> &BitcoinCli {
-        &self.bitcoin_cli
+    fn bitcoind_client(&self) -> &BitcoindClient {
+        &self.bitcoind_client
     }
 
     fn check_alive(&mut self) -> Result<(), TargetError> {

--- a/smite-scenarios/src/targets/ldk.rs
+++ b/smite-scenarios/src/targets/ldk.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 
 use bitcoin::secp256k1;
-use smite::bitcoin::BitcoinCli;
+use smite::bitcoin::BitcoindClient;
 use smite::process::{ManagedProcess, send_sigusr1};
 
 use super::bitcoind;
@@ -88,7 +88,7 @@ pub struct LdkTarget {
     bitcoind: ManagedProcess,
     pubkey: secp256k1::PublicKey,
     addr: SocketAddr,
-    bitcoin_cli: BitcoinCli,
+    bitcoind_client: BitcoindClient,
     #[allow(dead_code)] // TempDir auto-cleans on drop
     temp_dir: Option<tempfile::TempDir>,
 }
@@ -162,7 +162,7 @@ impl Target for LdkTarget {
     fn start(config: Self::Config) -> Result<Self, TargetError> {
         let (data_path, temp_dir) = bitcoind::resolve_data_dir()?;
 
-        let (bitcoind, bitcoin_cli) = bitcoind::start(&config.bitcoind_config(), &data_path)?;
+        let (bitcoind, bitcoind_client) = bitcoind::start(&config.bitcoind_config(), &data_path)?;
         let (ldk, pubkey) = Self::start_ldk(&config, &data_path)?;
         let addr = SocketAddr::from(([127, 0, 0, 1], config.ldk_p2p_port));
 
@@ -173,7 +173,7 @@ impl Target for LdkTarget {
             bitcoind,
             pubkey,
             addr,
-            bitcoin_cli,
+            bitcoind_client,
             temp_dir,
         })
     }
@@ -192,8 +192,8 @@ impl Target for LdkTarget {
         }
     }
 
-    fn bitcoin_cli(&self) -> &BitcoinCli {
-        &self.bitcoin_cli
+    fn bitcoind_client(&self) -> &BitcoindClient {
+        &self.bitcoind_client
     }
 
     fn check_alive(&mut self) -> Result<(), TargetError> {

--- a/smite-scenarios/src/targets/lnd.rs
+++ b/smite-scenarios/src/targets/lnd.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use bitcoin::secp256k1;
 use serde::Deserialize;
-use smite::bitcoin::BitcoinCli;
+use smite::bitcoin::BitcoindClient;
 use smite::process::ManagedProcess;
 
 use super::bitcoind;
@@ -102,7 +102,7 @@ pub struct LndTarget {
     coverage_pipes: Option<CoveragePipes>,
     pubkey: secp256k1::PublicKey,
     addr: SocketAddr,
-    bitcoin_cli: BitcoinCli,
+    bitcoind_client: BitcoindClient,
     #[allow(dead_code)] // TempDir auto-cleans on drop
     temp_dir: Option<tempfile::TempDir>,
 }
@@ -286,7 +286,7 @@ impl Target for LndTarget {
     fn start(config: Self::Config) -> Result<Self, TargetError> {
         let (data_path, temp_dir) = bitcoind::resolve_data_dir()?;
 
-        let (bitcoind, bitcoin_cli) = bitcoind::start(&config.bitcoind_config(), &data_path)?;
+        let (bitcoind, bitcoind_client) = bitcoind::start(&config.bitcoind_config(), &data_path)?;
         let (lnd, coverage_pipes, pubkey) = Self::start_lnd(&config, &data_path)?;
         let addr = SocketAddr::from(([127, 0, 0, 1], config.lnd_p2p_port));
 
@@ -298,7 +298,7 @@ impl Target for LndTarget {
             coverage_pipes,
             pubkey,
             addr,
-            bitcoin_cli,
+            bitcoind_client,
             temp_dir,
         })
     }
@@ -315,8 +315,8 @@ impl Target for LndTarget {
         LndRpc
     }
 
-    fn bitcoin_cli(&self) -> &BitcoinCli {
-        &self.bitcoin_cli
+    fn bitcoind_client(&self) -> &BitcoindClient {
+        &self.bitcoind_client
     }
 
     fn check_alive(&mut self) -> Result<(), TargetError> {

--- a/smite/src/bitcoin.rs
+++ b/smite/src/bitcoin.rs
@@ -1,11 +1,8 @@
-//! This module implements utilities for interacting with regtest
-//! `bitcoind` instances via `bitcoin-cli`.
+//! JSON-RPC client for the regtest `bitcoind` instances started by targets.
 
 use std::cmp::Ordering;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{Ipv4Addr, SocketAddr, TcpStream};
-use std::path::PathBuf;
-use std::process::Command;
 use std::str::FromStr;
 
 use bitcoin::consensus::encode::serialize_hex;
@@ -81,17 +78,22 @@ impl std::fmt::Display for RpcError {
     }
 }
 
+/// Why a JSON-RPC request produced no result.
+enum RequestError {
+    /// `bitcoind` could not be reached or did not answer with JSON-RPC.
+    Transport(std::io::Error),
+    /// `bitcoind` answered with a JSON-RPC error.
+    Rpc(RpcError),
+}
+
 /// Client for the regtest `bitcoind` started by a target.
 ///
-/// Per-input calls go over a single HTTP/1.1 keep-alive connection to the
-/// JSON-RPC server, so no process is spawned in the fuzzing loop. Startup-only
-/// calls still go through [`BitcoindClient::run`].
+/// All calls go over a single HTTP/1.1 keep-alive connection to the JSON-RPC
+/// server, so no process is spawned in the fuzzing loop.
 #[derive(Debug)]
 pub struct BitcoindClient {
     /// RPC port exposed by the regtest `bitcoind` instance.
     pub rpc_port: u16,
-    /// Path passed to `bitcoin-cli -datadir`.
-    pub bitcoind_dir: PathBuf,
     /// Keep-alive connection to the JSON-RPC server, opened on first use and
     /// reopened after `bitcoind` closes it (it drops idle connections after
     /// `-rpcservertimeout`).
@@ -101,17 +103,54 @@ pub struct BitcoindClient {
 impl Clone for BitcoindClient {
     /// Clones the connection info only; the clone opens its own connection.
     fn clone(&self) -> Self {
-        Self::new(self.rpc_port, self.bitcoind_dir.clone())
+        Self::new(self.rpc_port)
     }
 }
 
 impl BitcoindClient {
     #[must_use]
-    pub fn new(rpc_port: u16, bitcoind_dir: PathBuf) -> Self {
+    pub fn new(rpc_port: u16) -> Self {
         Self {
             rpc_port,
-            bitcoind_dir,
             conn: None,
+        }
+    }
+
+    /// Returns `true` once `bitcoind` answers RPCs, i.e. it is up and past
+    /// its warmup (during which every RPC is rejected with `-28`).
+    pub fn is_ready(&mut self) -> bool {
+        self.request("getblockchaininfo", &serde_json::json!([]))
+            .is_ok()
+    }
+
+    /// Creates a wallet named `name`, which `bitcoind` then keeps loaded.
+    ///
+    /// # Errors
+    ///
+    /// Returns the JSON-RPC error, e.g. when a wallet of that name already
+    /// exists in the data directory.
+    pub fn create_wallet(&mut self, name: &str) -> Result<(), RpcError> {
+        self.call("createwallet", &serde_json::json!([name]))
+            .map(|_| ())
+    }
+
+    /// Sends one JSON-RPC request over the keep-alive connection, treating a
+    /// transport failure as a programmer or environment error.
+    ///
+    /// # Panics
+    ///
+    /// If `bitcoind` cannot be reached or answers with something that is not
+    /// a JSON-RPC response. Startup code that expects that uses
+    /// [`BitcoindClient::is_ready`] instead.
+    fn call(
+        &mut self,
+        method: &str,
+        params: &serde_json::Value,
+    ) -> Result<serde_json::Value, RpcError> {
+        match self.request(method, params) {
+            Ok(result) => Ok(result),
+            Err(RequestError::Rpc(e)) => Err(e),
+            Err(RequestError::Transport(e)) => panic!("bitcoind {method} request failed: {e}"),
         }
     }
 
@@ -120,16 +159,11 @@ impl BitcoindClient {
     /// Returns the `result` field, or the server's JSON-RPC error. A
     /// connection that `bitcoind` has closed in the meantime is reopened and
     /// the request retried once.
-    ///
-    /// # Panics
-    ///
-    /// If `bitcoind` cannot be reached or answers with something that is not
-    /// a JSON-RPC response.
-    fn call(
+    fn request(
         &mut self,
         method: &str,
         params: &serde_json::Value,
-    ) -> Result<serde_json::Value, RpcError> {
+    ) -> Result<serde_json::Value, RequestError> {
         #[derive(Deserialize)]
         struct RpcResponse {
             #[serde(default)]
@@ -149,17 +183,26 @@ impl BitcoindClient {
             Ok(body) => body,
             Err(e) => {
                 // The server closes idle keep-alive connections; reconnect once.
-                log::debug!("bitcoind connection dropped ({e}), reconnecting");
+                log::debug!("bitcoind {method} failed ({e}), retrying on a fresh connection");
                 self.conn = None;
-                self.http_post(&request)
-                    .unwrap_or_else(|e| panic!("bitcoind {method} request failed: {e}"))
+                match self.http_post(&request) {
+                    Ok(body) => body,
+                    Err(e) => {
+                        self.conn = None;
+                        return Err(RequestError::Transport(e));
+                    }
+                }
             }
         };
 
-        let response: RpcResponse = serde_json::from_slice(&body)
-            .unwrap_or_else(|e| panic!("bitcoind {method} returned invalid JSON-RPC: {e}"));
+        let response: RpcResponse = serde_json::from_slice(&body).map_err(|e| {
+            self.conn = None;
+            RequestError::Transport(std::io::Error::other(format!(
+                "invalid JSON-RPC response: {e}"
+            )))
+        })?;
         match response.error {
-            Some(error) => Err(error),
+            Some(error) => Err(RequestError::Rpc(error)),
             None => Ok(response.result),
         }
     }
@@ -222,19 +265,6 @@ impl BitcoindClient {
         Ok(body)
     }
 
-    /// Creates a `bitcoin-cli` command preconfigured with the connection
-    /// arguments for this regtest node.
-    #[must_use]
-    pub fn run(&self) -> Command {
-        let mut cmd = Command::new("bitcoin-cli");
-        cmd.arg("-regtest")
-            .arg(format!("-datadir={}", self.bitcoind_dir.display()))
-            .arg(format!("-rpcport={}", self.rpc_port))
-            .arg("-rpcuser=rpcuser")
-            .arg("-rpcpassword=rpcpass");
-        cmd
-    }
-
     /// Mines the given number of blocks.
     ///
     /// Any transactions stored in `private_mempool` are included in the first
@@ -243,11 +273,15 @@ impl BitcoindClient {
     ///
     /// # Panics
     ///
-    /// If the `bitcoin-cli -generate` or `generateblock` command fails to
-    /// execute or exits non-zero.
+    /// If `generatetoaddress` or `generateblock` fails, e.g. `MineBlocks(0)`.
     pub fn mine_blocks(&mut self, num_blocks: u8, private_mempool: &[String]) {
+        let mine = |this: &mut Self, n: u8| {
+            this.generate(u32::from(n))
+                .unwrap_or_else(|e| panic!("generatetoaddress {n} failed: {e}"));
+        };
+
         if private_mempool.is_empty() {
-            self.generate(num_blocks);
+            mine(self, num_blocks);
             return;
         }
 
@@ -255,19 +289,23 @@ impl BitcoindClient {
         // remaining blocks normally.
         self.mine_block_including(private_mempool);
         if num_blocks > 1 {
-            self.generate(num_blocks - 1);
+            mine(self, num_blocks - 1);
         }
     }
 
-    /// Mines `num_blocks` blocks from the node's mempool via
-    /// `bitcoin-cli -generate`.
-    fn generate(&mut self, num_blocks: u8) {
+    /// Mines `num_blocks` blocks from the node's mempool to a fresh wallet
+    /// address.
+    ///
+    /// # Errors
+    ///
+    /// Returns the JSON-RPC error, e.g. for `num_blocks == 0`.
+    pub fn generate(&mut self, num_blocks: u32) -> Result<(), RpcError> {
         let address = self.get_new_address();
         self.call(
             "generatetoaddress",
             &serde_json::json!([num_blocks, address.to_string()]),
         )
-        .unwrap_or_else(|e| panic!("generatetoaddress {num_blocks} failed: {e}"));
+        .map(|_| ())
     }
 
     /// Mines a single block containing the current mempool together with the
@@ -279,9 +317,7 @@ impl BitcoindClient {
     ///
     /// # Panics
     ///
-    /// - If `bitcoin-cli getrawmempool`, `getnewaddress`, or `generateblock`
-    ///   fails to execute or exits non-zero.
-    /// - If `getrawmempool` does not return valid JSON.
+    /// - If `getrawmempool`, `getnewaddress`, or `generateblock` fails.
     /// - If `getnewaddress` does not return a valid regtest address.
     /// - If any transaction in `private_mempool` is consensus-invalid.
     /// - If the combined transaction list contains a duplicate rawtx/txid or is
@@ -302,8 +338,7 @@ impl BitcoindClient {
     ///
     /// # Panics
     ///
-    /// - If `bitcoin-cli getrawmempool` fails to execute or exits non-zero.
-    /// - If the output is not valid JSON.
+    /// If `getrawmempool` fails or does not return a txid list.
     fn get_raw_mempool(&mut self) -> Vec<String> {
         let result = self
             .call("getrawmempool", &serde_json::json!([]))
@@ -315,9 +350,8 @@ impl BitcoindClient {
     ///
     /// # Panics
     ///
-    /// - If `bitcoin-cli listunspent` fails to execute or exits non-zero.
-    /// - If the output is not valid JSON, or any entry has an invalid amount,
-    ///   txid, or hex scriptPubKey.
+    /// - If `listunspent` fails.
+    /// - If any entry has an invalid amount, txid, or hex scriptPubKey.
     #[must_use]
     pub fn get_utxos(&mut self) -> Vec<Utxo> {
         #[derive(Deserialize)]
@@ -362,8 +396,8 @@ impl BitcoindClient {
     ///
     /// # Panics
     ///
-    /// - If `bitcoin-cli getnewaddress` fails to execute or exits non-zero.
-    /// - If the output is not valid UTF-8 or not a valid regtest address.
+    /// - If `getnewaddress` fails.
+    /// - If the result is not a valid regtest address.
     #[must_use]
     pub fn get_new_address_script_pubkey(&mut self) -> ScriptBuf {
         self.get_new_address().script_pubkey()
@@ -373,8 +407,8 @@ impl BitcoindClient {
     ///
     /// # Panics
     ///
-    /// - If `bitcoin-cli getnewaddress` fails to execute or exits non-zero.
-    /// - If the output is not valid UTF-8 or not a valid regtest address.
+    /// - If `getnewaddress` fails.
+    /// - If the result is not a valid regtest address.
     fn get_new_address(&mut self) -> Address {
         let result = self
             .call("getnewaddress", &serde_json::json!([]))
@@ -400,14 +434,9 @@ impl BitcoindClient {
     ///
     /// # Panics
     ///
-    /// - If `bitcoin-cli signrawtransactionwithwallet` fails to execute or
-    ///   exits non-zero.
-    /// - If the sign output is not valid JSON.
-    /// - If signing returns `complete=false`.
-    /// - If `bitcoin-cli sendrawtransaction` fails to execute.
+    /// - If `signrawtransactionwithwallet` fails or returns `complete=false`.
     /// - If the broadcast is rejected for any reason other than a below-dust
     ///   output or a below-minimum relay feerate.
-    /// - If a successful broadcast does not return a valid UTF-8 txid.
     /// - If the broadcasted txid does not match the given transaction's txid.
     #[must_use]
     pub fn sign_and_broadcast_tx(&mut self, tx: &Transaction) -> Option<String> {
@@ -474,8 +503,7 @@ impl BitcoindClient {
     ///
     /// # Panics
     ///
-    /// If the `bitcoin-cli lockunspent` command fails to execute or exits
-    /// non-zero.
+    /// If `lockunspent` fails.
     pub fn lock_utxos(&mut self, outpoints: &[OutPoint]) {
         #[derive(Serialize)]
         struct LockOutpoint {
@@ -523,8 +551,7 @@ impl BitcoindClient {
     ///
     /// # Panics
     ///
-    /// - If the `bitcoin-cli getrawtransaction` command fails to execute.
-    /// - If the command succeeds but its output is not valid JSON.
+    /// If `getrawtransaction` fails for any reason other than an unknown txid.
     #[must_use]
     pub fn get_transaction_confirmations(&mut self, txid: Txid) -> u32 {
         self.get_raw_transaction_info(txid)
@@ -540,8 +567,7 @@ impl BitcoindClient {
     ///
     /// # Panics
     ///
-    /// - If `bitcoin-cli getrawtransaction` or `getblock` fails to execute.
-    /// - If either command succeeds but its output is not valid JSON.
+    /// - If `getrawtransaction` or `getblock` fails.
     /// - If `getblock` returns a block whose transaction list does not contain
     ///   the queried txid (would indicate an inconsistent bitcoind state).
     #[must_use]

--- a/smite/src/bitcoin.rs
+++ b/smite/src/bitcoin.rs
@@ -2,6 +2,8 @@
 //! `bitcoind` instances via `bitcoin-cli`.
 
 use std::cmp::Ordering;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{Ipv4Addr, SocketAddr, TcpStream};
 use std::path::PathBuf;
 use std::process::Command;
 use std::str::FromStr;
@@ -60,17 +62,166 @@ struct RawTransactionInfo {
     blockhash: Option<String>,
 }
 
-/// Connection info for invoking `bitcoin-cli` against the regtest `bitcoind`
-/// started by a target.
-#[derive(Debug, Clone)]
-pub struct BitcoinCli {
+/// `rpcuser:rpcpassword` credentials every target starts `bitcoind` with.
+const RPC_CREDENTIALS: &str = "rpcuser:rpcpass";
+
+/// `getrawtransaction` error code for a transaction unknown to the node.
+const RPC_INVALID_ADDRESS_OR_KEY: i64 = -5;
+
+/// A JSON-RPC error returned by `bitcoind`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RpcError {
+    pub code: i64,
+    pub message: String,
+}
+
+impl std::fmt::Display for RpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "error code: {}, message: {}", self.code, self.message)
+    }
+}
+
+/// Client for the regtest `bitcoind` started by a target.
+///
+/// Per-input calls go over a single HTTP/1.1 keep-alive connection to the
+/// JSON-RPC server, so no process is spawned in the fuzzing loop. Startup-only
+/// calls still go through [`BitcoindClient::run`].
+#[derive(Debug)]
+pub struct BitcoindClient {
     /// RPC port exposed by the regtest `bitcoind` instance.
     pub rpc_port: u16,
     /// Path passed to `bitcoin-cli -datadir`.
     pub bitcoind_dir: PathBuf,
+    /// Keep-alive connection to the JSON-RPC server, opened on first use and
+    /// reopened after `bitcoind` closes it (it drops idle connections after
+    /// `-rpcservertimeout`).
+    conn: Option<BufReader<TcpStream>>,
 }
 
-impl BitcoinCli {
+impl Clone for BitcoindClient {
+    /// Clones the connection info only; the clone opens its own connection.
+    fn clone(&self) -> Self {
+        Self::new(self.rpc_port, self.bitcoind_dir.clone())
+    }
+}
+
+impl BitcoindClient {
+    #[must_use]
+    pub fn new(rpc_port: u16, bitcoind_dir: PathBuf) -> Self {
+        Self {
+            rpc_port,
+            bitcoind_dir,
+            conn: None,
+        }
+    }
+
+    /// Sends one JSON-RPC request over the keep-alive connection.
+    ///
+    /// Returns the `result` field, or the server's JSON-RPC error. A
+    /// connection that `bitcoind` has closed in the meantime is reopened and
+    /// the request retried once.
+    ///
+    /// # Panics
+    ///
+    /// If `bitcoind` cannot be reached or answers with something that is not
+    /// a JSON-RPC response.
+    fn call(
+        &mut self,
+        method: &str,
+        params: &serde_json::Value,
+    ) -> Result<serde_json::Value, RpcError> {
+        #[derive(Deserialize)]
+        struct RpcResponse {
+            #[serde(default)]
+            result: serde_json::Value,
+            error: Option<RpcError>,
+        }
+
+        let request = serde_json::json!({
+            "jsonrpc": "1.0",
+            "id": "smite",
+            "method": method,
+            "params": params,
+        })
+        .to_string();
+
+        let body = match self.http_post(&request) {
+            Ok(body) => body,
+            Err(e) => {
+                // The server closes idle keep-alive connections; reconnect once.
+                log::debug!("bitcoind connection dropped ({e}), reconnecting");
+                self.conn = None;
+                self.http_post(&request)
+                    .unwrap_or_else(|e| panic!("bitcoind {method} request failed: {e}"))
+            }
+        };
+
+        let response: RpcResponse = serde_json::from_slice(&body)
+            .unwrap_or_else(|e| panic!("bitcoind {method} returned invalid JSON-RPC: {e}"));
+        match response.error {
+            Some(error) => Err(error),
+            None => Ok(response.result),
+        }
+    }
+
+    /// Posts `body` to the JSON-RPC endpoint and returns the response body,
+    /// whatever the HTTP status: `bitcoind` reports JSON-RPC errors as HTTP
+    /// 500 with the JSON-RPC error in the body.
+    fn http_post(&mut self, body: &str) -> std::io::Result<Vec<u8>> {
+        let conn = if let Some(conn) = self.conn.as_mut() {
+            conn
+        } else {
+            let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, self.rpc_port));
+            let stream = TcpStream::connect(addr)?;
+            stream.set_nodelay(true)?;
+            self.conn.insert(BufReader::new(stream))
+        };
+
+        let request = format!(
+            "POST / HTTP/1.1\r\n\
+             Host: localhost\r\n\
+             Authorization: Basic {}\r\n\
+             Content-Type: application/json\r\n\
+             Content-Length: {}\r\n\
+             \r\n{body}",
+            base64(RPC_CREDENTIALS.as_bytes()),
+            body.len(),
+        );
+        conn.get_mut().write_all(request.as_bytes())?;
+
+        // Status line, then headers up to the blank line. Only
+        // `Content-Length` matters: bitcoind never chunks its responses.
+        let mut line = String::new();
+        let mut content_length = None;
+        loop {
+            line.clear();
+            if conn.read_line(&mut line)? == 0 {
+                return Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof));
+            }
+            let trimmed = line.trim_end_matches("\r\n");
+            if trimmed.is_empty() {
+                break;
+            }
+            if let Some(value) = trimmed
+                .split_once(':')
+                .filter(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+                .map(|(_, value)| value.trim())
+            {
+                content_length = Some(
+                    value
+                        .parse::<usize>()
+                        .map_err(|e| std::io::Error::other(format!("bad Content-Length: {e}")))?,
+                );
+            }
+        }
+
+        let len = content_length
+            .ok_or_else(|| std::io::Error::other("bitcoind response without Content-Length"))?;
+        let mut body = vec![0u8; len];
+        conn.read_exact(&mut body)?;
+        Ok(body)
+    }
+
     /// Creates a `bitcoin-cli` command preconfigured with the connection
     /// arguments for this regtest node.
     #[must_use]
@@ -94,7 +245,7 @@ impl BitcoinCli {
     ///
     /// If the `bitcoin-cli -generate` or `generateblock` command fails to
     /// execute or exits non-zero.
-    pub fn mine_blocks(&self, num_blocks: u8, private_mempool: &[String]) {
+    pub fn mine_blocks(&mut self, num_blocks: u8, private_mempool: &[String]) {
         if private_mempool.is_empty() {
             self.generate(num_blocks);
             return;
@@ -110,19 +261,13 @@ impl BitcoinCli {
 
     /// Mines `num_blocks` blocks from the node's mempool via
     /// `bitcoin-cli -generate`.
-    fn generate(&self, num_blocks: u8) {
-        let mine_out = self
-            .run()
-            .arg("-generate")
-            .arg(num_blocks.to_string())
-            .output()
-            .expect("bitcoin-cli -generate should not fail");
-        assert!(
-            mine_out.status.success(),
-            "bitcoin-cli -generate {} failed: {}",
-            num_blocks,
-            String::from_utf8_lossy(&mine_out.stderr)
-        );
+    fn generate(&mut self, num_blocks: u8) {
+        let address = self.get_new_address();
+        self.call(
+            "generatetoaddress",
+            &serde_json::json!([num_blocks, address.to_string()]),
+        )
+        .unwrap_or_else(|e| panic!("generatetoaddress {num_blocks} failed: {e}"));
     }
 
     /// Mines a single block containing the current mempool together with the
@@ -141,24 +286,16 @@ impl BitcoinCli {
     /// - If any transaction in `private_mempool` is consensus-invalid.
     /// - If the combined transaction list contains a duplicate rawtx/txid or is
     ///   not topologically ordered.
-    fn mine_block_including(&self, private_mempool: &[String]) {
+    fn mine_block_including(&mut self, private_mempool: &[String]) {
         let mut txs = self.get_raw_mempool();
         txs.extend_from_slice(private_mempool);
-        let txs_json = serde_json::to_string(&txs).expect("tx list serializes to valid JSON");
 
         let address = self.get_new_address();
-        let gen_out = self
-            .run()
-            .arg("generateblock")
-            .arg(address.to_string())
-            .arg(&txs_json)
-            .output()
-            .expect("bitcoin-cli generateblock should not fail");
-        assert!(
-            gen_out.status.success(),
-            "bitcoin-cli generateblock failed: {}",
-            String::from_utf8_lossy(&gen_out.stderr)
-        );
+        self.call(
+            "generateblock",
+            &serde_json::json!([address.to_string(), txs]),
+        )
+        .unwrap_or_else(|e| panic!("generateblock failed: {e}"));
     }
 
     /// Returns the txids currently in the node's mempool.
@@ -167,18 +304,11 @@ impl BitcoinCli {
     ///
     /// - If `bitcoin-cli getrawmempool` fails to execute or exits non-zero.
     /// - If the output is not valid JSON.
-    fn get_raw_mempool(&self) -> Vec<String> {
-        let out = self
-            .run()
-            .arg("getrawmempool")
-            .output()
-            .expect("bitcoin-cli getrawmempool should not fail");
-        assert!(
-            out.status.success(),
-            "bitcoin-cli getrawmempool failed: {}",
-            String::from_utf8_lossy(&out.stderr)
-        );
-        serde_json::from_slice(&out.stdout).expect("getrawmempool should return valid JSON")
+    fn get_raw_mempool(&mut self) -> Vec<String> {
+        let result = self
+            .call("getrawmempool", &serde_json::json!([]))
+            .unwrap_or_else(|e| panic!("getrawmempool failed: {e}"));
+        serde_json::from_value(result).expect("getrawmempool should return a txid list")
     }
 
     /// Returns the wallet's spendable UTXOs, sorted deterministically.
@@ -189,7 +319,7 @@ impl BitcoinCli {
     /// - If the output is not valid JSON, or any entry has an invalid amount,
     ///   txid, or hex scriptPubKey.
     #[must_use]
-    pub fn get_utxos(&self) -> Vec<Utxo> {
+    pub fn get_utxos(&mut self) -> Vec<Utxo> {
         #[derive(Deserialize)]
         struct UnspentOutput {
             txid: String,
@@ -200,19 +330,11 @@ impl BitcoinCli {
             spendable: bool,
         }
 
-        let utxo_out = self
-            .run()
-            .arg("listunspent")
-            .output()
-            .expect("bitcoin-cli listunspent should not fail");
-        assert!(
-            utxo_out.status.success(),
-            "bitcoin-cli listunspent failed: {}",
-            String::from_utf8_lossy(&utxo_out.stderr)
-        );
-
+        let result = self
+            .call("listunspent", &serde_json::json!([]))
+            .unwrap_or_else(|e| panic!("listunspent failed: {e}"));
         let utxos: Vec<UnspentOutput> =
-            serde_json::from_slice(&utxo_out.stdout).expect("listunspent should return valid JSON");
+            serde_json::from_value(result).expect("listunspent should return a UTXO list");
 
         let mut spendable: Vec<Utxo> = utxos
             .into_iter()
@@ -243,7 +365,7 @@ impl BitcoinCli {
     /// - If `bitcoin-cli getnewaddress` fails to execute or exits non-zero.
     /// - If the output is not valid UTF-8 or not a valid regtest address.
     #[must_use]
-    pub fn get_new_address_script_pubkey(&self) -> ScriptBuf {
+    pub fn get_new_address_script_pubkey(&mut self) -> ScriptBuf {
         self.get_new_address().script_pubkey()
     }
 
@@ -253,20 +375,14 @@ impl BitcoinCli {
     ///
     /// - If `bitcoin-cli getnewaddress` fails to execute or exits non-zero.
     /// - If the output is not valid UTF-8 or not a valid regtest address.
-    fn get_new_address(&self) -> Address {
-        let addr_out = self
-            .run()
-            .arg("getnewaddress")
-            .output()
-            .expect("bitcoin-cli getnewaddress should not fail");
-        assert!(
-            addr_out.status.success(),
-            "bitcoin-cli getnewaddress failed: {}",
-            String::from_utf8_lossy(&addr_out.stderr)
-        );
-
-        let addr_str = String::from_utf8(addr_out.stdout).expect("bitcoin address is valid UTF-8");
-        Address::from_str(addr_str.trim())
+    fn get_new_address(&mut self) -> Address {
+        let result = self
+            .call("getnewaddress", &serde_json::json!([]))
+            .unwrap_or_else(|e| panic!("getnewaddress failed: {e}"));
+        let addr_str = result
+            .as_str()
+            .expect("getnewaddress should return a string");
+        Address::from_str(addr_str)
             .and_then(|a| a.require_network(Network::Regtest))
             .expect("getnewaddress should return a valid address")
     }
@@ -294,7 +410,7 @@ impl BitcoinCli {
     /// - If a successful broadcast does not return a valid UTF-8 txid.
     /// - If the broadcasted txid does not match the given transaction's txid.
     #[must_use]
-    pub fn sign_and_broadcast_tx(&self, tx: &Transaction) -> Option<String> {
+    pub fn sign_and_broadcast_tx(&mut self, tx: &Transaction) -> Option<String> {
         #[derive(Deserialize)]
         struct SignRawTransactionResponse {
             hex: String,
@@ -311,53 +427,35 @@ impl BitcoinCli {
 
         let tx_hex = serialize_hex(tx);
 
-        let signed_out = self
-            .run()
-            .arg("signrawtransactionwithwallet")
-            .arg(&tx_hex)
-            .output()
-            .expect("bitcoin-cli signrawtransactionwithwallet should not fail");
-        assert!(
-            signed_out.status.success(),
-            "bitcoin-cli signrawtransactionwithwallet failed: {}",
-            String::from_utf8_lossy(&signed_out.stderr)
-        );
-
-        let signed_tx: SignRawTransactionResponse = serde_json::from_slice(&signed_out.stdout)
-            .expect("signrawtransactionwithwallet should return valid JSON");
+        let result = self
+            .call("signrawtransactionwithwallet", &serde_json::json!([tx_hex]))
+            .unwrap_or_else(|e| panic!("signrawtransactionwithwallet failed: {e}"));
+        let signed_tx: SignRawTransactionResponse = serde_json::from_value(result)
+            .expect("signrawtransactionwithwallet should return hex and complete");
         assert!(
             signed_tx.complete,
             "signrawtransactionwithwallet returned complete=false"
         );
 
-        let broadcast_out = self
-            .run()
-            .arg("sendrawtransaction")
-            .arg(&signed_tx.hex)
-            // Disable the high-feerate cap and accept any fee rate for broadcast.
-            .arg("0")
-            .output()
-            .expect("bitcoin-cli sendrawtransaction should not fail");
-
-        if !broadcast_out.status.success() {
-            let stderr = String::from_utf8_lossy(&broadcast_out.stderr);
+        // The `0` disables the high-feerate cap so any fee rate is broadcast.
+        let broadcast = self.call("sendrawtransaction", &serde_json::json!([signed_tx.hex, 0]));
+        let broadcast_txid = match broadcast {
+            Ok(result) => result,
             // If the feerate is below the default minimum relay feerate, or any
             // output is below its dust threshold, return the transactions so
             // they can be mined directly, bypassing mempool policy.
-            if stderr.contains("tx with dust output") || stderr.contains("min relay fee not met") {
+            Err(e) if e.message.contains("dust") || e.message.contains("min relay fee not met") => {
                 return Some(signed_tx.hex);
             }
-            panic!("bitcoin-cli sendrawtransaction failed: {stderr}");
-        }
+            Err(e) => panic!("sendrawtransaction failed: {e}"),
+        };
 
         // Safe because bitcoind descriptor wallets currently default to native
         // SegWit, so signing does not alter the txid computed from the unsigned
         // Transaction.
-        let broadcast_txid = String::from_utf8(broadcast_out.stdout)
-            .expect("sendrawtransaction should return a valid UTF-8 txid");
         assert_eq!(
-            broadcast_txid.trim(),
-            txid.to_string(),
+            broadcast_txid.as_str(),
+            Some(txid.to_string().as_str()),
             "sendrawtransaction returned unexpected txid"
         );
 
@@ -378,7 +476,7 @@ impl BitcoinCli {
     ///
     /// If the `bitcoin-cli lockunspent` command fails to execute or exits
     /// non-zero.
-    pub fn lock_utxos(&self, outpoints: &[OutPoint]) {
+    pub fn lock_utxos(&mut self, outpoints: &[OutPoint]) {
         #[derive(Serialize)]
         struct LockOutpoint {
             txid: String,
@@ -396,20 +494,8 @@ impl BitcoinCli {
                 vout: o.vout,
             })
             .collect();
-        let locks_json = serde_json::to_string(&locks).expect("outpoints serialize to valid JSON");
-
-        let lock_out = self
-            .run()
-            .arg("lockunspent")
-            .arg("false")
-            .arg(&locks_json)
-            .output()
-            .expect("bitcoin-cli lockunspent should not fail");
-        assert!(
-            lock_out.status.success(),
-            "bitcoin-cli lockunspent failed: {}",
-            String::from_utf8_lossy(&lock_out.stderr)
-        );
+        self.call("lockunspent", &serde_json::json!([false, locks]))
+            .unwrap_or_else(|e| panic!("lockunspent failed: {e}"));
     }
 
     /// Calls `getrawtransaction <txid> 1` and returns the parsed response, or
@@ -419,24 +505,16 @@ impl BitcoinCli {
     ///
     /// - If the command fails to execute.
     /// - If the command succeeds but its output is not valid JSON.
-    fn get_raw_transaction_info(&self, txid: Txid) -> Option<RawTransactionInfo> {
-        let tx_out = self
-            .run()
-            .arg("getrawtransaction")
-            .arg(txid.to_string())
-            .arg("1")
-            .output()
-            .expect("bitcoin-cli getrawtransaction should not fail");
-
-        // A non-zero exit means the transaction is unknown to the node.
-        if !tx_out.status.success() {
-            return None;
-        }
-
-        let tx_info: RawTransactionInfo = serde_json::from_slice(&tx_out.stdout)
-            .expect("getrawtransaction should return valid JSON");
-
-        Some(tx_info)
+    fn get_raw_transaction_info(&mut self, txid: Txid) -> Option<RawTransactionInfo> {
+        let result = match self.call(
+            "getrawtransaction",
+            &serde_json::json!([txid.to_string(), 1]),
+        ) {
+            Ok(result) => result,
+            Err(e) if e.code == RPC_INVALID_ADDRESS_OR_KEY => return None,
+            Err(e) => panic!("getrawtransaction failed: {e}"),
+        };
+        Some(serde_json::from_value(result).expect("getrawtransaction should return tx info"))
     }
 
     /// Returns the number of confirmations for the transaction with the given
@@ -448,7 +526,7 @@ impl BitcoinCli {
     /// - If the `bitcoin-cli getrawtransaction` command fails to execute.
     /// - If the command succeeds but its output is not valid JSON.
     #[must_use]
-    pub fn get_transaction_confirmations(&self, txid: Txid) -> u32 {
+    pub fn get_transaction_confirmations(&mut self, txid: Txid) -> u32 {
         self.get_raw_transaction_info(txid)
             .map_or(0, |info| info.confirmations)
     }
@@ -467,7 +545,7 @@ impl BitcoinCli {
     /// - If `getblock` returns a block whose transaction list does not contain
     ///   the queried txid (would indicate an inconsistent bitcoind state).
     #[must_use]
-    pub fn get_transaction_block_position(&self, txid: Txid) -> Option<TxBlockPosition> {
+    pub fn get_transaction_block_position(&mut self, txid: Txid) -> Option<TxBlockPosition> {
         #[derive(Deserialize)]
         struct GetBlockResponse {
             height: u32,
@@ -480,22 +558,11 @@ impl BitcoinCli {
         // confirmed.
         let blockhash = self.get_raw_transaction_info(txid)?.blockhash?;
 
-        let block_out = self
-            .run()
-            .arg("getblock")
-            .arg(&blockhash)
-            .arg("1")
-            .output()
-            .expect("bitcoin-cli getblock should not fail");
-        assert!(
-            block_out.status.success(),
-            "bitcoin-cli getblock {} failed: {}",
-            blockhash,
-            String::from_utf8_lossy(&block_out.stderr)
-        );
-
+        let result = self
+            .call("getblock", &serde_json::json!([blockhash, 1]))
+            .unwrap_or_else(|e| panic!("getblock {blockhash} failed: {e}"));
         let block: GetBlockResponse =
-            serde_json::from_slice(&block_out.stdout).expect("getblock should return valid JSON");
+            serde_json::from_value(result).expect("getblock should return height and tx list");
 
         let txid_str = txid.to_string();
         let tx_index = block
@@ -509,5 +576,40 @@ impl BitcoinCli {
             block_height: block.height,
             tx_index,
         })
+    }
+}
+
+/// Standard base64 with padding, enough for the `Authorization: Basic` header.
+fn base64(input: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let mut buf = [0u8; 3];
+        buf[..chunk.len()].copy_from_slice(chunk);
+        let n = u32::from_be_bytes([0, buf[0], buf[1], buf[2]]);
+        for i in 0..4 {
+            if i <= chunk.len() {
+                let idx = usize::try_from((n >> (18 - 6 * i)) & 0x3f).expect("6-bit index");
+                out.push(char::from(ALPHABET[idx]));
+            } else {
+                out.push('=');
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::base64;
+
+    #[test]
+    fn base64_matches_rfc4648_vectors() {
+        assert_eq!(base64(b""), "");
+        assert_eq!(base64(b"f"), "Zg==");
+        assert_eq!(base64(b"fo"), "Zm8=");
+        assert_eq!(base64(b"foo"), "Zm9v");
+        assert_eq!(base64(b"foob"), "Zm9vYg==");
+        assert_eq!(base64(b"rpcuser:rpcpass"), "cnBjdXNlcjpycGNwYXNz");
     }
 }

--- a/smite/src/lib.rs
+++ b/smite/src/lib.rs
@@ -6,7 +6,7 @@
 //! provides the building blocks that scenarios and targets are built on.
 //!
 //! # Modules
-//! - [`bitcoin`] - Utilities for interacting with `bitcoind` instances via `bitcoin-cli`.
+//! - [`bitcoin`] - JSON-RPC client for `bitcoind` instances.
 //! - [`bolt`] - BOLT message encoding and decoding.
 //! - [`channel_tx`] - BOLT 3 channel transaction construction (funding and commitment).
 //! - [`noise`] - BOLT 8 `Noise_XK` encrypted transport.

--- a/workloads/cln/Dockerfile
+++ b/workloads/cln/Dockerfile
@@ -65,7 +65,6 @@ WORKDIR /tmp
 RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz && \
     tar -xzf bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz && \
     mv bitcoin-${BITCOIN_VERSION}/bin/bitcoind /usr/local/bin/bitcoind && \
-    mv bitcoin-${BITCOIN_VERSION}/bin/bitcoin-cli /usr/local/bin/bitcoin-cli && \
     rm -rf bitcoin-${BITCOIN_VERSION}*
 
 # Clone CLN and build with AFL instrumentation.
@@ -166,9 +165,8 @@ COPY --from=builder /usr/local/bin/lightningd /usr/local/bin/lightningd
 COPY --from=builder /usr/local/bin/lightning-cli /usr/local/bin/lightning-cli
 COPY --from=builder /usr/local/libexec/c-lightning/ /usr/local/libexec/c-lightning/
 
-# Copy Bitcoin Core binaries
+# Copy bitcoind
 COPY --from=builder /usr/local/bin/bitcoind /usr/local/bin/bitcoind
-COPY --from=builder /usr/local/bin/bitcoin-cli /usr/local/bin/bitcoin-cli
 
 # Copy crash handlers and cln-scenario binary
 COPY --from=builder /nyx-crash-handler.so /crash-handler.so /
@@ -176,7 +174,7 @@ COPY --from=builder /smite/target/release/cln_${SCENARIO} /cln-scenario
 
 # Default to the local crash handler; init.sh overrides with the Nyx version.
 # ClnTarget forwards this as LD_PRELOAD on lightningd only, so it doesn't
-# interfere with helper processes (lightning-cli, bitcoin-cli).
+# interfere with helper processes (lightning-cli).
 ENV SMITE_CRASH_HANDLER=/crash-handler.so
 
 # ASan options for CLN binaries (instrumented with -fsanitize=address):

--- a/workloads/cln/Dockerfile.coverage
+++ b/workloads/cln/Dockerfile.coverage
@@ -56,7 +56,6 @@ WORKDIR /tmp
 RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz && \
     tar -xzf bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz && \
     mv bitcoin-${BITCOIN_VERSION}/bin/bitcoind /usr/local/bin/bitcoind && \
-    mv bitcoin-${BITCOIN_VERSION}/bin/bitcoin-cli /usr/local/bin/bitcoin-cli && \
     rm -rf bitcoin-${BITCOIN_VERSION}*
 
 # Clone CLN and build with LLVM source-based coverage instrumentation.
@@ -130,9 +129,8 @@ COPY --from=builder /usr/local/bin/lightningd /usr/local/bin/lightningd
 COPY --from=builder /usr/local/bin/lightning-cli /usr/local/bin/lightning-cli
 COPY --from=builder /usr/local/libexec/c-lightning/ /usr/local/libexec/c-lightning/
 
-# Copy Bitcoin Core binaries
+# Copy bitcoind
 COPY --from=builder /usr/local/bin/bitcoind /usr/local/bin/bitcoind
-COPY --from=builder /usr/local/bin/bitcoin-cli /usr/local/bin/bitcoin-cli
 
 # Copy the cln-scenario binary
 COPY --from=builder /smite/target/release/cln_${SCENARIO} /cln-scenario

--- a/workloads/eclair/Dockerfile
+++ b/workloads/eclair/Dockerfile
@@ -24,7 +24,6 @@ WORKDIR /tmp
 RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz && \
     tar -xzf bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz && \
     mv bitcoin-${BITCOIN_VERSION}/bin/bitcoind /usr/local/bin/bitcoind && \
-    mv bitcoin-${BITCOIN_VERSION}/bin/bitcoin-cli /usr/local/bin/bitcoin-cli && \
     rm -rf bitcoin-${BITCOIN_VERSION}*
 
 # Clone and build Eclair.
@@ -102,9 +101,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copy Eclair distribution (bin/eclair-node.sh + lib/*.jar)
 COPY --from=builder /opt/eclair /opt/eclair
 
-# Copy Bitcoin Core binaries
+# Copy bitcoind
 COPY --from=builder /usr/local/bin/bitcoind /usr/local/bin/bitcoind
-COPY --from=builder /usr/local/bin/bitcoin-cli /usr/local/bin/bitcoin-cli
 
 # Copy coverage agent and JNI shared library
 COPY --from=builder /eclair-sancov/target/eclair-sancov-0.0.0.jar /eclair-sancov.jar

--- a/workloads/eclair/Dockerfile.coverage
+++ b/workloads/eclair/Dockerfile.coverage
@@ -26,7 +26,6 @@ WORKDIR /tmp
 RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz && \
     tar -xzf bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz && \
     mv bitcoin-${BITCOIN_VERSION}/bin/bitcoind /usr/local/bin/bitcoind && \
-    mv bitcoin-${BITCOIN_VERSION}/bin/bitcoin-cli /usr/local/bin/bitcoin-cli && \
     rm -rf bitcoin-${BITCOIN_VERSION}*
 
 # Download JaCoCo for coverage instrumentation and report generation.
@@ -77,9 +76,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copy Eclair distribution (bin/eclair-node.sh + lib/*.jar)
 COPY --from=builder /opt/eclair /opt/eclair
 
-# Copy Bitcoin Core binaries
+# Copy bitcoind
 COPY --from=builder /usr/local/bin/bitcoind /usr/local/bin/bitcoind
-COPY --from=builder /usr/local/bin/bitcoin-cli /usr/local/bin/bitcoin-cli
 
 # Copy JaCoCo agent and CLI JARs
 COPY --from=builder /jacoco/lib/jacocoagent.jar /jacocoagent.jar

--- a/workloads/ldk/Dockerfile
+++ b/workloads/ldk/Dockerfile
@@ -39,7 +39,6 @@ WORKDIR /tmp
 RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz && \
     tar -xzf bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz && \
     mv bitcoin-${BITCOIN_VERSION}/bin/bitcoind /usr/local/bin/bitcoind && \
-    mv bitcoin-${BITCOIN_VERSION}/bin/bitcoin-cli /usr/local/bin/bitcoin-cli && \
     rm -rf bitcoin-${BITCOIN_VERSION}*
 
 # Build ldk-node-wrapper with AFL instrumentation.
@@ -98,9 +97,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=builder /ldk-wrapper/target/release/ldk-node-wrapper /usr/local/bin/ldk-node-wrapper
 COPY --from=builder /nyx-crash-handler.so /crash-handler.so /
 
-# Copy Bitcoin Core binaries
+# Copy bitcoind
 COPY --from=builder /usr/local/bin/bitcoind /usr/local/bin/bitcoind
-COPY --from=builder /usr/local/bin/bitcoin-cli /usr/local/bin/bitcoin-cli
 
 # Copy the ldk-scenario binary
 COPY --from=builder /smite/target/release/ldk_${SCENARIO} /ldk-scenario

--- a/workloads/ldk/Dockerfile.coverage
+++ b/workloads/ldk/Dockerfile.coverage
@@ -35,7 +35,6 @@ WORKDIR /tmp
 RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz && \
     tar -xzf bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz && \
     mv bitcoin-${BITCOIN_VERSION}/bin/bitcoind /usr/local/bin/bitcoind && \
-    mv bitcoin-${BITCOIN_VERSION}/bin/bitcoin-cli /usr/local/bin/bitcoin-cli && \
     rm -rf bitcoin-${BITCOIN_VERSION}*
 
 # Build ldk-node-wrapper with LLVM source-based coverage instrumentation.
@@ -81,9 +80,8 @@ RUN ldconfig
 # Copy ldk-node-wrapper binary (coverage-instrumented)
 COPY --from=builder /ldk-wrapper/target/release/ldk-node-wrapper /usr/local/bin/ldk-node-wrapper
 
-# Copy Bitcoin Core binaries
+# Copy bitcoind
 COPY --from=builder /usr/local/bin/bitcoind /usr/local/bin/bitcoind
-COPY --from=builder /usr/local/bin/bitcoin-cli /usr/local/bin/bitcoin-cli
 
 # Copy the ldk-scenario binary
 COPY --from=builder /smite/target/release/ldk_${SCENARIO} /ldk-scenario

--- a/workloads/lnd/Dockerfile
+++ b/workloads/lnd/Dockerfile
@@ -50,7 +50,6 @@ WORKDIR /tmp
 RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz && \
     tar -xzf bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz && \
     mv bitcoin-${BITCOIN_VERSION}/bin/bitcoind /usr/local/bin/bitcoind && \
-    mv bitcoin-${BITCOIN_VERSION}/bin/bitcoin-cli /usr/local/bin/bitcoin-cli && \
     rm -rf bitcoin-${BITCOIN_VERSION}*
 
 # Build lncli without sancov.go
@@ -89,9 +88,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=builder /lnd/cmd/lnd/lnd /usr/local/bin/lnd
 COPY --from=builder /lnd/cmd/lncli/lncli /usr/local/bin/lncli
 
-# Copy Bitcoin Core binaries
+# Copy bitcoind
 COPY --from=builder /usr/local/bin/bitcoind /usr/local/bin/bitcoind
-COPY --from=builder /usr/local/bin/bitcoin-cli /usr/local/bin/bitcoin-cli
 
 # Copy the lnd-scenario binary
 COPY --from=builder /smite/target/release/lnd_${SCENARIO} /lnd-scenario

--- a/workloads/lnd/Dockerfile.coverage
+++ b/workloads/lnd/Dockerfile.coverage
@@ -37,7 +37,6 @@ WORKDIR /tmp
 RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz && \
     tar -xzf bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz && \
     mv bitcoin-${BITCOIN_VERSION}/bin/bitcoind /usr/local/bin/bitcoind && \
-    mv bitcoin-${BITCOIN_VERSION}/bin/bitcoin-cli /usr/local/bin/bitcoin-cli && \
     rm -rf bitcoin-${BITCOIN_VERSION}*
 
 # Build LND with Go's native coverage instrumentation.
@@ -80,9 +79,8 @@ COPY --from=builder /lnd/cmd/lncli/lncli /usr/local/bin/lncli
 # Copy LND source (needed for go tool cover -html to generate annotated report)
 COPY --from=builder /lnd /lnd
 
-# Copy Bitcoin Core binaries
+# Copy bitcoind
 COPY --from=builder /usr/local/bin/bitcoind /usr/local/bin/bitcoind
-COPY --from=builder /usr/local/bin/bitcoin-cli /usr/local/bin/bitcoin-cli
 
 # Copy the lnd-scenario binary
 COPY --from=builder /smite/target/release/lnd_${SCENARIO} /lnd-scenario


### PR DESCRIPTION
Every bitcoind call from the fuzz loop forked a `bitcoin-cli` process inside the Nyx VM; a full funding flow spawned 12 of them. This replaces the transport with a small HTTP/1.1 client over one `TcpStream` to bitcoind's JSON-RPC port, then moves the startup calls onto it too so `bitcoin-cli` disappears from the images.

Benchmark

<details><summary>input:</summary>

```
smitebot print-ir ./input.bin
v0 = LoadChainHashFromContext()
v1 = LoadChannelId(0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
v2 = LoadAmount(100000)
v3 = LoadAmount(0)
v4 = LoadAmount(546)
v5 = LoadAmount(100000000)
v6 = LoadAmount(1000)
v7 = LoadAmount(1000)
v8 = LoadFeeratePerKw(2500)
v9 = LoadU16(144)
v10 = LoadU16(483)
v11 = LoadPrivateKey(0x2121212121212121212121212121212121212121212121212121212121212121)
v12 = DerivePoint(v11)
v13 = LoadPrivateKey(0x2222222222222222222222222222222222222222222222222222222222222222)
v14 = DerivePoint(v13)
v15 = LoadPrivateKey(0x2323232323232323232323232323232323232323232323232323232323232323)
v16 = DerivePoint(v15)
v17 = LoadPrivateKey(0x2424242424242424242424242424242424242424242424242424242424242424)
v18 = DerivePoint(v17)
v19 = LoadPrivateKey(0x2525252525252525252525252525252525252525252525252525252525252525)
v20 = DerivePoint(v19)
v21 = LoadPrivateKey(0x2626262626262626262626262626262626262626262626262626262626262626)
v22 = DerivePoint(v21)
v23 = LoadU8(0)
v24 = LoadShutdownScript(Empty)
v25 = LoadChannelType(StaticRemoteKey)
v26 = BuildOpenChannel(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v12, v14, v16, v18, v20, v22, v23, v24, v25)
v27 = SendOpenChannel(v26)
v28 = RecvAcceptChannel(v27)
v29 = ExtractFundingPubkey(v28)
v30 = CreateFundingTransaction(v12, v29, v2, v8)
v31 = SendFundingCreated(v30, v11, v1)
v32 = RecvFundingSigned(v31)
BroadcastTransaction(v30)
MineBlocks(6)
v35 = LoadPrivateKey(0x2727272727272727272727272727272727272727272727272727272727272727)
v36 = DerivePoint(v35)
v37 = LookupShortChannelId(v30)
SendChannelReady{include_alias=false}(v32, v36, v37)
RecvChannelReady()
```

</details> 

master:
```
  aggregate over 3 runs:
    execs/sec: mean 13.8  stddev 0.3  min 13.5  max 14.1
    boot + snapshot: mean 3.935 s
    latency (mean across runs):
      min 65.18 ms  mean 72.71 ms  median 73.82 ms  p99 78.82 ms  max 79.84 ms
    input execution (mean across runs): mean 70.41 ms  median 71.53 ms
    nyx overhead (mean across runs):     mean 2.30 ms  median 2.48 ms
    failed iterations: 0 / 600
    coverage determinism: 92.5% stable (4129 / 55086 edges fluctuated, summed over runs)
```
This pr:

```
  aggregate over 3 runs:
    execs/sec: mean 15.0  stddev 0.0  min 14.9  max 15.0
    boot + snapshot: mean 3.893 s
    latency (mean across runs):
      min 59.04 ms  mean 66.82 ms  median 66.70 ms  p99 69.81 ms  max 72.00 ms
    input execution (mean across runs): mean 64.40 ms  median 64.28 ms
    nyx overhead (mean across runs):     mean 2.42 ms  median 2.40 ms
    failed iterations: 0 / 600
    coverage determinism: 74.7% stable (13998 / 55302 edges fluctuated, summed over runs)
```
About 10% on this input. Inputs with fewer bitcoind calls gain proportionally less.